### PR TITLE
[DOCS-3] Set up a changelog system in External Product Documentation

### DIFF
--- a/Changelog_Template.md
+++ b/Changelog_Template.md
@@ -1,0 +1,45 @@
+This is the template file for changelogs. See the following
+[Confluence page](https://zombie.atlassian.net/wiki/spaces/PRODUCT/pages/2040136662/Create+Changelog+Entries) for the detailed procedure.
+
+TLDR, the following template includes _sample_ entries that you can modify/include
+in the `content/en/Changelog/_index.md` file.
+
+1. If you're including API changes, find the version
+1. Create a new branch.
+1. Insert new changes in the content/en/Changelog/_index.md file, just before the next oldest changelog entry.
+1. Substitute existing changes in each category.
+   1. If there are no changes in a category, remove it by deleting the title.
+1. Create a PR and assign the **review** to a member of the [External Product Documentation]() team. If none are available, [...]
+
+## 2022-12-25: [API Version major.minor.patch]
+
+### Added
+
+- Some icon tooltip to the \<name the menu> menu.
+- Another tooltip defining \<something important>.
+- Option to copy a pentest in Pentests screen.
+- API: `new_field` to /some endpoint.
+
+### Changed
+
+- Renamed "Push a \<something>" to "Create a <something>" in Pentests screen.
+- API: Increased output from /some endpoint to 20 assets/page.
+
+### Deprecated
+
+- Integration with \<something>.
+- API: Output from the /important endpoint will change from `old_thing` to `new_thing`.
+
+### Removed
+
+- Integration with \<something else>. Replaced with \<something new>.
+- API: Output from the /important endpoint no longer includes `old_thing`. Replaced with `new_thing`.
+
+### Fixed
+
+- Corrected grammar errors on \<name> screen.
+- API: The /important endpoint returns real time data again.
+
+### Security
+
+<!-- Security fix changelog entries require approval from our security team -->

--- a/content/en/Changelog/_index.md
+++ b/content/en/Changelog/_index.md
@@ -1,0 +1,21 @@
+
+---
+title: "Changelog"
+linkTitle: "Changelog"
+weight: 30
+menu:
+  main:
+    weight: 30
+---
+
+{{% pageinfo %}}
+This page includes notable external changes to Cobalt software.
+
+The format is based on guidance from [Keep a Changelog](http://keepachangelog.com/).
+
+This changelog includes two types of versioning:
+
+- Product: [Calendar Versioning](https://calver.org)
+- API: [Semantic Versioning](http://semver.org/)
+{{% /pageinfo %}}
+

--- a/content/en/Changelog/_index.md
+++ b/content/en/Changelog/_index.md
@@ -19,3 +19,32 @@ This changelog includes two types of versioning:
 - API: [Semantic Versioning](http://semver.org/)
 {{% /pageinfo %}}
 
+## 2022-12-25: [API Version major.minor.patch]
+
+### Added
+
+- Some icon tooltip to the \<name the menu> menu.
+- Another tooltip defining \<something important>.
+- Option to copy a pentest in Pentests screen.
+- API: `new_field` to /some endpoint.
+
+### Changed
+
+- Renamed "Push a \<something>" to "Create a <something>" in Pentests screen.
+- API: Increased output from /some endpoint to 20 assets/page.
+
+### Deprecated
+
+- Integration with \<something>.
+- API: Output from the /important endpoint will change from `old_thing` to `new_thing`.
+
+### Removed
+
+- Integration with \<something else>. Replaced with \<something new>.
+- API: Output from the /important endpoint no longer includes `old_thing`. Replaced with `new_thing`.
+
+### Fixed
+
+- Corrected grammar errors on \<name> screen.
+- API: The /important endpoint returns real time data again.
+


### PR DESCRIPTION
I've laid out what I'm visualizing for the bi-weekly changelog, as described in https://zombie.atlassian.net/wiki/spaces/PRODUCT/pages/1955692590/DRAFT+Changelog

I've laid out the step-by-step process in both:
- [Confluence](https://zombie.atlassian.net/wiki/spaces/PRODUCT/pages/2040136662/Create+Changelog+Entries)
- [Changelog_Template.md](https://github.com/cobalthq/cobalt-product-public-docs/pull/20/files#diff-6da0595a83f745aba6aaa07790c7aaf1bf2122d7d074f58ac074d1f138d8c12b)

My success criteria: Does this PR provide enough info for any developer to set up a changelog entry after every external-facing sprint demo?

You can review the build in our external product docs in https://deploy-preview-20--sample-changelog.netlify.app/changelog/ 