### PR TITLE
[DOCS-24] Set up docs on cobalt.io

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,6 @@ HUGO_VERSION = "0.87.0"
 HUGO_ENV = "production"
 
 [[redirects]]
-  from = "https://cobalt-docs.netlify.app"
-  to = "https://cobalt.io/docs"
+  from = "https://cobalt-docs.netlify.app/*"
+  to = "https://cobalt.io/docs/:splat"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,5 +8,5 @@ HUGO_ENV = "production"
 
 [[redirects]]
   from = "https://cobalt-docs.netlify.app"
-  to = "https://developer.cobalt.io"
+  to = "https://cobalt.io/docs"
   status = 301


### PR DESCRIPTION
Hi @aialferov . 

After discussions with Jake Fox (SEO), I'd like to move developer.cobalt.io to cobalt.io/docs

This PR sets up the redirect from Netlify to cobalt.io docs.

I'd also like a redirect from developer.cobalt.io -> cobalt.io/docs, which I think is in your domain.

Related: https://zombie.atlassian.net/browse/INFRA-1262