### PR TITLE
[DOCS-26] Test Netlify link checker plugin, checklinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 public/
 resources/
 node_modules/
-tech-doc-hugo
+tech-doc-hugo/
+tmp/
 

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,12 @@
+DirectoryPath: "public"
+EnforceHTTPS: true
+IgnoreURLs:
+- "example.com"
+- "www.example.com"
+IgnoreInternalURLs:
+- "/misc/js/script.js"
+IgnoreDirs:
+- "lib"
+CacheExpires: "6h"
+IgnoreDirectoryMissingTrailingSlash: true
+IgnoreExternalBrokenLinks: true

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ In addition, the following tools can help you verify ("lint") proposed documenta
 
 ### Tools in evaluation:
 
-- A link checker <!-- such as [html-proofer](https://github.com/gjtorikian/html-proofer) -->
 - [Vale](https://github.com/errata-ai/vale), a syntax-aware linter 
 - [Netlify](https://www.netlify.com/) for CI tests and doc deployment
 
@@ -73,6 +72,33 @@ Once you've made your working copy of the site repo, from the repo root folder, 
 ```
 hugo server -D
 ```
+
+## Check links
+
+You can check links with htmltest. The `.htmltest.yml` includes options to
+avoid trailing slashes. The `htmltest` command works on the HTML content built
+in the public/ subdirectory.
+
+After you fix broken links, run the following commands to rebuild content in
+the public/ subdirectory:
+
+```
+hugo mod clean
+hugo
+```
+
+If you don't run these commands, you'll see the same link errors that you "thought" you fixed.
+
+You can then rerun the htmltest command.
+
+While there are a couple of open issues with the output, related to the link
+to our Zendesk articles, it does detect other broken links.
+
+```
+  Non-OK status: 403 --- index.html --> https://cobaltio.zendesk.com/hc/en-us/categories/360005476672-Cobalt-Platform
+  Non-OK status: 403 --- index.html --> https://cobaltio.zendesk.com/hc/en-us/categories/360005476672-Cobalt-Platform
+```
+
 ## Search Engine Optimization (SEO)
 
 Includes custom settings in layouts/partials/head.html for <title> and <meta> tags. Based in part on https://harrycresswell.com/writing/hugo-seo-accurate-page-titles/.

--- a/content/en/Getting started/Pentest objectives/pentest-target.md
+++ b/content/en/Getting started/Pentest objectives/pentest-target.md
@@ -20,7 +20,7 @@ pointing to their location(s) on the Internet.
 | Mobile           | URL where anyone can download a mobile app, such as on Google Play or the Apple App Store.                                               |
 | API              | Base URL of the API. You can define the endpoints / queries in the Instructions text box. |
 | External Network | IP addresses or the IP network address.                                                   |
-| Internal Network | IP network address. External IP address for the [Jump Box]().                             |
+| Internal Network | IP network address. External IP address for the [Jump Box](../../glossary/#jump-box).                             |
 | Cloud Config     | IP address(es) and FQDNs of your cloud components.                                        |
 
 Once you've defined the target(s), the next step is to specify the


### PR DESCRIPTION
As described in DOCS-26

Netlify link checker does not work
htmltest almost works
Unable to install html-proofer due to Ruby installation isuses

Review another day. Include "howto" for `htmltest` in the README.