### PR TITLE
[DOCS-32] Fix extra space between link text and punctuation

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,1 +1,4 @@
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text }}</a>
+<a href="{{ .Destination | safeURL }}" {{ with .Title}} title="{{ . }}" {{ end }}
+  {{ if strings.HasPrefix .Destination "mailto" }} target="_blank" {{ end }}
+  {{ if strings.HasPrefix .Destination "https" }} target="_blank" rel="noreferrer noopener" {{ end }}
+>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
Solution, based on using vim: https://www.reddit.com/r/vim/comments/a6jr6u/set_nofixendofline_doesnt_work_in_my/.
Once I implemented the change in my vim configuration file (~/.vimrc), I opened a new terminal and rewrote the noted render-link.html file, which solved the problem :) 

(Apparently, the same problem exists when using other IDEs, ref https://github.com/gohugoio/hugo/issues/6832) 

Before: 
![Screen Shot 2021-10-21 at 1 21 30 PM](https://user-images.githubusercontent.com/84352037/138357571-786f35b9-f98a-4ea7-aa4a-f767e164dbeb.png)

After:
![Screen Shot 2021-10-21 at 1 29 38 PM](https://user-images.githubusercontent.com/84352037/138357593-e906b3f5-eecb-468a-b617-4db2a8e618be.png)

