### PR TITLE
[DOCS-50] Testing 'Expand' code

### DIFF
--- a/content/en/Getting started/_index.md
+++ b/content/en/Getting started/_index.md
@@ -20,6 +20,8 @@ the confidence of your customers. You want results as soon as possible.
 
 You've come to the right place.
 
+{{%expand "Learn more." %}}
+
 If you're considering Cobalt, use this document to help you visualize the process.
 If you've already purchased Cobalt credits, use this document to start your journey.
 
@@ -35,6 +37,7 @@ step by step, and set [expectations](./what-to-expect).
 When you've finished this Getting Started Guide, you'll have a plan and scope that
 our pentesters can use to test your assets. When you purchase credits from Cobalt,
 we send you an email invitation, which you can use to [Sign in to Cobalt](./sign-in).
+{{% /expand%}}
 
 ## Overview
 

--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -1,0 +1,17 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+<div class="expand">
+    <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fas fa-chevron-down' : 'fas fa-chevron-right';});});">
+        <i style="font-size:x-small;" class="fas fa-chevron-right"></i>
+        <span>
+        {{$expandMessage := T "Expand-title"}}
+    	{{ if .IsNamedParams }}
+    	{{.Get "default" | default $expandMessage}}
+    	{{else}}
+    	{{.Get 0 | default $expandMessage}}
+    	{{end}}
+    	</span>
+    </div>
+    <div class="expand-content" style="display: none;">
+        {{.Inner | safeHTML}}
+    </div>
+</div>

--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -1,7 +1,7 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 <div class="expand">
     <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fas fa-chevron-down' : 'fas fa-chevron-right';});});">
-        <i style="font-size:large;" class="fas fa-chevron-right"></i>
+        <i style="font-size:x-large;" class="fas fa-chevron-right"></i>
         <span>
         {{$expandMessage := T "Expand-title"}}
     	{{ if .IsNamedParams }}

--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -1,7 +1,7 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 <div class="expand">
     <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fas fa-chevron-down' : 'fas fa-chevron-right';});});">
-        <i style="font-size:x-large;" class="fas fa-chevron-right"></i>
+        <i style="font-size:x-large; color: blue" class="fas fa-chevron-right"></i>
         <span>
         {{$expandMessage := T "Expand-title"}}
     	{{ if .IsNamedParams }}

--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -1,7 +1,7 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 <div class="expand">
     <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fas fa-chevron-down' : 'fas fa-chevron-right';});});">
-        <i style="font-size:x-small;" class="fas fa-chevron-right"></i>
+        <i style="font-size:large;" class="fas fa-chevron-right"></i>
         <span>
         {{$expandMessage := T "Expand-title"}}
     	{{ if .IsNamedParams }}

--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -1,7 +1,7 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 <div class="expand">
     <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fas fa-chevron-down' : 'fas fa-chevron-right';});});">
-        <i style="font-size:x-large; color: blue" class="fas fa-chevron-right"></i>
+        <i style="font-size:x-large; color: #0047AB" class="fas fa-chevron-right"></i>
         <span>
         {{$expandMessage := T "Expand-title"}}
     	{{ if .IsNamedParams }}


### PR DESCRIPTION
This turned out better than I expected. @dannyleong39 I'd love your opinion/approval of this. I'm going to share with Stef as well before merging.

I think this can be an excellent tool to minimize any "walls of text" in our docs, based on Marketing feedback.

You can review the build here: https://deploy-preview-100--cobalt-docs.netlify.app/getting-started/
<img width="419" alt="Screen Shot 2022-03-01 at 12 14 48 PM" src="https://user-images.githubusercontent.com/84352037/156248339-17220989-9ef5-4491-b845-52be8fc07e13.png">

