### PR TITLE
[DOCS-93] Update when we support pentest reports

### DIFF
--- a/content/en/Getting started/Assets/coverage.md
+++ b/content/en/Getting started/Assets/coverage.md
@@ -75,10 +75,6 @@ different asset sizes and coverage levels:
 {{% pentest-report-requirements %}}
 <!-- For content, see the following file: layouts/shortcodes/pentest-report-requirements.html -->
 
-If you want a pentest report, you must set up a test of at least two credits. 
-If you have a one credit pentest, you'll still have access to the non-report
-items listed in [Pentest Expectations](https://developer.cobalt.io/getting-started/what-to-expect/).
-
 We do not create multiple pentest reports for large assets. For example, if you
 want separate pentest reports for different APIs, set up different pentests
 for each API.

--- a/content/en/Getting started/What to Expect/_index.md
+++ b/content/en/Getting started/What to Expect/_index.md
@@ -62,7 +62,7 @@ results. Here's what you can expect:
    However, we report _all_ findings. For more information, see the following blog post
    on how you can [Customize Your Pentest
    Reports](https://cobalt.io/blog/cobalt-platform-deep-dive-customize-your-pentest-reports-per-your-needs).
-1. <a id="report-timing">Within days, our pentesters share a formal report.
+1. <a id="report-timing">Within a few days, our pentesters share a formal report.
    You're welcome to download this
    [sample test report (PDF)](/gsg/GettingStarted_Sample_WebApp_Report.pdf) for a web app.
 

--- a/content/en/Getting started/What to Expect/_index.md
+++ b/content/en/Getting started/What to Expect/_index.md
@@ -62,7 +62,7 @@ results. Here's what you can expect:
    However, we report _all_ findings. For more information, see the following blog post
    on how you can [Customize Your Pentest
    Reports](https://cobalt.io/blog/cobalt-platform-deep-dive-customize-your-pentest-reports-per-your-needs).
-1. <a id="report-timing">Within a few days, our pentesters share a formal report.
+1. <a id="report-timing">Based on your Service Level Agreement, our pentesters then share a formal report.
    You're welcome to download this
    [sample test report (PDF)](/gsg/GettingStarted_Sample_WebApp_Report.pdf) for a web app.
 

--- a/content/en/Getting started/What to Expect/_index.md
+++ b/content/en/Getting started/What to Expect/_index.md
@@ -62,7 +62,7 @@ results. Here's what you can expect:
    However, we report _all_ findings. For more information, see the following blog post
    on how you can [Customize Your Pentest
    Reports](https://cobalt.io/blog/cobalt-platform-deep-dive-customize-your-pentest-reports-per-your-needs).
-1. <a id="report-timing">Within days, our pentesters share a more formal pentest report.
+1. <a id="report-timing">Within days, our pentesters share a formal report.
    You're welcome to download this
    [sample test report (PDF)](/gsg/GettingStarted_Sample_WebApp_Report.pdf) for a web app.
 

--- a/content/en/Getting started/What to Expect/_index.md
+++ b/content/en/Getting started/What to Expect/_index.md
@@ -62,7 +62,7 @@ results. Here's what you can expect:
    However, we report _all_ findings. For more information, see the following blog post
    on how you can [Customize Your Pentest
    Reports](https://cobalt.io/blog/cobalt-platform-deep-dive-customize-your-pentest-reports-per-your-needs).
-1. Within days, our pentesters share a more formal pentest report.
+1. <a id="report-timing">Within days, our pentesters share a more formal pentest report.
    You're welcome to download this
    [sample test report (PDF)](/gsg/GettingStarted_Sample_WebApp_Report.pdf) for a web app.
 

--- a/layouts/shortcodes/pentest-report-requirements.html
+++ b/layouts/shortcodes/pentest-report-requirements.html
@@ -1,3 +1,3 @@
-If you want a pentest report, you must set up a test of at least two credits. 
-If you have a one credit pentest, you'll still have access to the non-report
+If you want a pentest report, you generally must set up a test of at least two (2) credits. 
+If you have a one (1) credit pentest, you'll still have access to the non-report
 items listed in [Pentest Expectations](https://developer.cobalt.io/getting-started/what-to-expect/).


### PR DESCRIPTION
This should work for now, but I'll need to update with DOCS-94 for when we roll out our new credit definitions.

TLDR: to see the changes as built, see:

- https://deploy-preview-102--cobalt-docs.netlify.app/getting-started/assets/coverage/#pentest-reports
- https://deploy-preview-102--cobalt-docs.netlify.app/getting-started/checklist/#reports

The content of these pages both pull from [this file](https://github.com/cobalthq/cobalt-product-public-docs/blob/DOCS-93_support_automated_pentest_message/layouts/shortcodes/pentest-report-requirements.html)

Once merged, I'll propose a message (in the internal issue, DOCS-93)