### PR TITLE
[DOCS-97] Remove bottom list menu for clarity

### DIFF
--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,0 +1,22 @@
+{{ define "main" }}
+<div class="td-content">
+	<h1>{{ .Title }}</h1>
+  {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	<header class="article-meta">
+		{{ partial "taxonomy_terms_article_wrapper.html" . }}
+		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+			{{ partial "reading-time.html" . }}
+		{{ end }}
+	</header>
+	{{ .Content }}
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
+		{{ partial "feedback.html" .Site.Params.ui.feedback }}
+		<br />
+	{{ end }}
+	{{ if (.Site.DisqusShortname) }}
+		<br />
+		{{ partial "disqus-comment.html" . }}
+	{{ end }}
+	{{ partial "page-meta-lastmod.html" . }}
+</div>
+{{ end }}

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -2,7 +2,7 @@
 <br>
 <hr size="8" width="100%" color="0047AB">  
 <br>
-  <p><b>Was this page helpful?</b></p>
+  <p><b><i>Was this page really helpful?</i></b></p>
 
         <a class="btn btn-primary mr-3 mb-4">
            Yes <i class="fas"></i>

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -1,5 +1,8 @@
 <div id="feedback">
-  <p>Was this page helpful?</p>
+<hr size="8" width="90%" color="0047AB">  
+<br>
+<br>
+  <p><b>Was this page helpful?</b></p>
 
         <a class="btn btn-primary mr-3 mb-4">
            Yes <i class="fas"></i>

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -2,7 +2,7 @@
 <br>
 <hr size="8" width="100%" color="0047AB">  
 <br>
-  <p><b><i>Was this page really helpful?</i></b></p>
+  <p><b>Was this page helpful?</b></p>
 
         <a class="btn btn-primary mr-3 mb-4">
            Yes <i class="fas"></i>

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -1,6 +1,5 @@
 <div id="feedback">
-<hr size="8" width="90%" color="0047AB">  
-<br>
+<hr size="8" width="100%" color="0047AB">  
 <br>
   <p><b>Was this page helpful?</b></p>
 

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -1,4 +1,5 @@
 <div id="feedback">
+<br>
 <hr size="8" width="100%" color="0047AB">  
 <br>
   <p><b>Was this page helpful?</b></p>

--- a/layouts/partials/taxonomy_terms_article.html
+++ b/layouts/partials/taxonomy_terms_article.html
@@ -1,0 +1,12 @@
+{{ $context := .context }}
+{{ $taxo := .taxo }}
+{{ if (gt (len ($context.GetTerms $taxo)) 0)}}
+<div class="taxonomy taxonomy-terms-article taxo-{{ urlize $taxo }}">
+  <h5 class="taxonomy-title">{{ humanize $taxo }}:</h5>
+  <ul class="taxonomy-terms">
+    {{ range ($context.GetTerms $taxo) }}
+      <li><a class="taxonomy-term" href="{{ .Permalink }}" data-taxonomy-term="{{ urlize .LinkTitle }}"><span class="taxonomy-label">{{ .LinkTitle }}</span></a></li>
+    {{ end }}
+  </ul>
+</div>
+{{ end }}

--- a/layouts/partials/taxonomy_terms_article_wrapper.html
+++ b/layouts/partials/taxonomy_terms_article_wrapper.html
@@ -1,0 +1,16 @@
+{{ $context := . }}
+{{ if isset .Site.Params "taxonomy" }}
+  {{ if isset .Site.Params.Taxonomy "taxonomypageheader" }}
+    {{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
+      {{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo) }}
+    {{ end }}
+  {{ else }}
+    {{ range $taxo, $taxo_map := .Site.Taxonomies }}
+      {{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo) }}
+    {{ end }}
+  {{ end }}
+{{ else }}
+  {{ range $taxo, $taxo_map := .Site.Taxonomies }}
+    {{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo) }}
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
In several docs pages, we have two sets of links to other pages, which IMO is confusing and poor UX. @yogipetkar I think this change helps minimize the distraction that you suggested in your (internal) Slack comment, as shown in the (internal) issue, DOCS-97.

cc @dannyleong39 as I think this promotes a "better UX"



![Screen Shot 2022-03-15 at 7 18 10 AM](https://user-images.githubusercontent.com/84352037/158398106-56fabc69-f946-4555-8201-ba17670a3706.png)



As you can see from the build of this PR, I've now removed the links at the bottom of the page. I still need to set up more separation between our text and the feedback options -- so I'm moving this PR to "draft"


<img width="1411" alt="Screen Shot 2022-03-15 at 7 19 32 AM" src="https://user-images.githubusercontent.com/84352037/158398569-9296b918-b3dc-4d9e-bb13-0dce289c78d3.png">

