### PR TITLE
[DOCS-123] Set up defintions for Cobalt org and pentest users

### DIFF
--- a/content/en/Getting started/Pentest objectives/test-credentials.md
+++ b/content/en/Getting started/Pentest objectives/test-credentials.md
@@ -31,7 +31,7 @@ If you've set up dedicated accounts:
   - Share documentation on how your pentesters can set their own passwords.
   - If necessary, share username/password (or other credential) information using the _secure_ channel of your choice.
 - Describe the user role along with associated permissions and/or privileges.
-- Include other authentication requirements such as two-factor authentication (2FA).
+- Include other authentication requirements such as [multi-factor authentication (MFA)](../../glossary/#multi-factor-authentication).
 - Once the pentest (and any retests) are complete, delete the dedicated accounts.
 
 Depending on the methodology, we may also perform

--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -78,14 +78,19 @@ released in 2021.
 ## Cobalt Users
 
 When using the Cobalt UI, you may encounter a variety of different users, in the following
-categories:
+roles:
 
 - Organization Roles: If you're a Cobalt customer, your account may have one or more of the following roles:
-  - Organization Owner: Also known as an _Org Owner_
-  - Organization Member: Also known as an _Org Member_
-  - Pentest Team Member: Also known as a _PT Team Member_
+  - Organization Owner
+  - Organization Member
+  - Pentest Team Member
 
-- Pentester Roles: If you're a Cobalt pentester, you may be a _PT Pentester_ or a _PT Lead_.
+- Pentester Roles: Cobalt pentesters who are assigned to your pentest have one of two roles:
+  - Lead
+  - Pentester
+
+  Some Cobalt pentesters may be a _Lead_ in one test, a _Pentester_ in a second test, and
+  possibly no role and no involvement in your other pentests.
 
 Select Cobalt employees may be assigned as administrators, as _Cobalt Staff_.
 
@@ -95,39 +100,52 @@ article: [What do the user roles mean?](https://cobaltio.zendesk.com/hc/en-us/ar
 <!-- Per https://zombie.atlassian.net/browse/DOCS-5 I should add info from an internal
 spreadsheet, but need to find pull code in Hugo -->
 
+### Organization Owner
+
+An _Organization Owner_ is the administrator for a customer organization within the Cobalt app. As such, they can:
+
+- Add/remove the users of their choice, by their email addresses, as an _Organization Member_
+  or _Organization Owner_.
+- View collaborators, the members of their pentest team. That team includes:
+  - _Pentest Team Member_, typically an organization employee.
+  - _Pentest Lead_, the Cobalt pentester responsible for the pentest.
+  - _Pentester_, one or more additional Cobalt pentesters whose helping with the pentest.
+  Smaller pentests may only have a _Pentest Lead_.
+
+- An _Organization Owner_ may also be a [_Pentest Team Member_](#pentest-team-member).
+
+- If allowed by their {{% ptaas-tier %}}, they can also manage
+[multi-factor authentication (MFA)](#multi-factor-authentication) as well as
+[SAML](#security-assertion-markup-language) settings for the users in their organization.
+
+An _Organization Owner_ also has top-level (sudo) administrative privileges for their
+organizations in the Cobalt app.
+
 ### Organization Member
 
-An _Org Member_ is a user of the Cobalt App who can create an [asset](#asset) or a
+An _Organization Member_ is a user of the Cobalt App who can create a
 [pentest](#pentest). That user can also see the pentesters who are working on their asset.
 If allowed by their {{% ptaas-tier %}}, they can also manage integration with Jira and GitHub.
 
-### Organization Owner
-
-An _Org Owner_ is the administrator for a customer organization within the Cobalt app. As such,
-they can:
-
-- Add/remove the users of their choice, by their email addresses, as an _Org Member_ or a
-  _PT Team Member_.
-- View collaborators, the members of their pentest team. That team includes 
-  - _PT Team Members_
-  - _PT Lead_
-  - _PT Pentester_ (when applicable)
-- If allowed by their {{% ptaas-tier %}}, they can also manage
-[SAML](#security-assertion-markup-language) settings for the users in their organization.
+- An _Organization Member_ may also be a [_Pentest Team Member_](#pentest-team-member).
 
 ### Pentest Team Member
 
-A _PT Team Member_ is a customer representative during a pentest. That user can review and
-respond to each [finding](#finding) identified by a Cobalt pentester.
+A _Pentest Team Member_ is a customer (organization) representative during a specific pentest.
+That user can review and respond to each [finding](#finding) identified by a Cobalt _Pentester_ or _Pentest Lead_.
+
+That _Pentest Team Member_ can also add one ore more users as a _Pentest Team Member_. 
+
+A _Pentest Team Member_ does not have to be an _Organization Owner_ or an _Organization Member_.
 
 ### Pentest Lead
 
-A _PT Lead_ is a Cobalt pentester who leads other Cobalt pentesters in their efforts to test
-an asset. When applicable, the _PT Lead_ also drafts the [pentest report](#pentest-report).
+A _Pentest Lead_ is a Cobalt pentester who leads other Cobalt pentesters in their efforts to test
+an asset. When applicable, the Pentest Lead also drafts the [pentest report](#pentest-report).
 
 ### Pentester
 
-A _PT Pentester_ is a Cobalt pentester whose working with a _PT Lead_ to test a specific asset.
+A _Pentester_ is a Cobalt pentester whose working with a _Pentest Lead_ to test a specific asset.
 
 ### Cobalt Staff
 
@@ -199,6 +217,15 @@ screens fall into several archetypes.
 You may have multiple screens of an archtype. For example, you may have 10 mobile screens for
 the onboarding archtype.
 
+## Multi-factor Authentication
+<!-- `Multi-factor` is consistent with Google terminology  -->
+
+Authentication which uses two or more different factors, which may include:
+- Something you know, such as a password or a PIN number
+- Something you have, such as an identity token
+- Something you are, which works with biometric authentication
+<!-- source: https://csrc.nist.gov/glossary/term/mfa -->
+
 ## Open Web Application Security Project (OWASP)
 
 [OWASP](https://owasp.org) is a nonprofit foundation with "Top 10" security
@@ -214,11 +241,6 @@ wired, analog, or digital.
 
 Operations Security, commonly known as OpSec, identifies critical information, and if/how it
 may be used by opponents or enemies. OpSec measures can reduce security risks.
-
-## Org Owner
-
-A Cobalt term for users who have top-level (sudo) administrative privileges for their organizations
-in the Cobalt app.
 
 ## Pentest
 

--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -80,7 +80,7 @@ released in 2021.
 When using the Cobalt UI, you may encounter a variety of different users, in the following
 categories:
 
-- Organization Roles: If you're a Cobalt customer, your account may have one of the following roles:
+- Organization Roles: If you're a Cobalt customer, your account may have one or more of the following roles:
   - Organization Owner: Also known as an _Org Owner_
   - Organization Member: Also known as an _Org Member_
   - Pentest Team Member: Also known as a _PT Team Member_

--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -123,8 +123,8 @@ organizations in the Cobalt app.
 
 ### Organization Member
 
-An _Organization Member_ is a user of the Cobalt App who can create a
-[pentest](#pentest). That user can also see the pentesters who are working on their asset.
+An _Organization Member_ is a user of the Cobalt App who can create an [asset](#asset) as well
+as a [pentest](#pentest). That user can also see the pentesters who are working on their asset.
 If allowed by their {{% ptaas-tier %}}, they can also manage integration with Jira and GitHub.
 
 - An _Organization Member_ may also be a [_Pentest Team Member_](#pentest-team-member).
@@ -134,7 +134,7 @@ If allowed by their {{% ptaas-tier %}}, they can also manage integration with Ji
 A _Pentest Team Member_ is a customer (organization) representative during a specific pentest.
 That user can review and respond to each [finding](#finding) identified by a Cobalt _Pentester_ or _Pentest Lead_.
 
-That _Pentest Team Member_ can also add one ore more users as a _Pentest Team Member_. 
+That _Pentest Team Member_ can also add one or more users as a _Pentest Team Member_. 
 
 A _Pentest Team Member_ does not have to be an _Organization Owner_ or an _Organization Member_.
 
@@ -145,7 +145,7 @@ an asset. When applicable, the Pentest Lead also drafts the [pentest report](#pe
 
 ### Pentester
 
-A _Pentester_ is a Cobalt pentester whose working with a _Pentest Lead_ to test a specific asset.
+A _Pentester_ is a Cobalt pentester who works with a _Pentest Lead_ to test a specific asset.
 
 ### Cobalt Staff
 
@@ -244,7 +244,10 @@ may be used by opponents or enemies. OpSec measures can reduce security risks.
 
 ## Pentest
 
-Short for penetration test.
+Short for penetration test. As described in the [Getting Started Guide](/getting-started/),
+you can draft a pentest. Once you submit it for review, Cobalt reviews your pentest and assigns
+a [Pentest Lead](#pentest-lead) and frequently one or more [Pentesters](#pentester) who then
+test the [asset](#asset) specified in your pentest.
 
 ## Pentest as a Service (PtaaS)
 

--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -75,6 +75,50 @@ refines best practice security solutions.
 One of the test criteria used by our pentesters is [CIS Controls v8](https://www.cisecurity.org/controls/v8),
 released in 2021.
 
+## Cobalt Users
+
+When using the Cobalt UI, you may encounter a variety of different users, in the following
+categories:
+
+- Organization Roles: If you're a Cobalt customer, you may be an `Org Owner`, `Org Member`, or
+  a `PT Team Member`..
+- Pentester Roles: If you're a Cobalt pentester, you may be a `PT Pentester` or a `PT Lead`.
+  `Pentest Lead`.
+
+Select Cobalt employees may be assigned as administrators, as `Cobalt Staff`.
+
+### Org Member
+
+An `Org Member` is a user of the Cobalt App who can create an [asset](#asset) or a
+[pentest](#pentest). That user can also see the pentesters who are working on their asset.
+If allowed by their {{% ptaas-tier %}}, they can also manage integration with Jira and GitHub.
+
+### Org Owner
+
+An `Org Owner` can also add/remove the users of their choice, by their email addresses, as
+`Org Owner` or `Org Member`. They can also manage the [Org Members](#org-member) assigned to a
+specific pentest. If allowed by their {{% ptaas-tier %}}, they can also manage
+[SAML](#security-assertion-markup-language-saml) settings for the users in their organization.
+
+### PT Team Member
+
+A `PT Team Member` is a customer representative during a pentest. That user can review and
+respond to each [finding](#finding) identified by a Cobalt pentester.
+
+### PT Lead
+
+A `PT Lead` is a Cobalt pentester who leads other Cobalt pentesters in their efforts to test
+an asset. When applicable, the `PT Lead` also drafts the [pentest report](#pentest-report).
+
+### PT Pentester
+
+A `PT Pentester` is a Cobalt pentester whose participating in testing an asset.
+
+### Cobalt Staff
+
+Cobalt Staff members may help you manage the users in your organization. They may also help
+manage work on your pentests.
+
 ## Dynamic Page
 
 Web applications typically include _static_ and _dynamic_ web pages. A Dynamic Page includes content
@@ -208,6 +252,8 @@ To fix a vulnerability identified by a pentest or incident report. Examples:
 Contrast with [mitigate](#mitigate). This reflects how we use **remediate** at
 Cobalt, and differs slightly from the NIST definition of 
 [remediation](https://csrc.nist.gov/glossary/term/remediation).
+
+## Security Assertion Markup Language (SAML)
 
 ## SANS Institute
 

--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -272,7 +272,7 @@ the [Security Assertion Markup Language (SAML)](https://www.oasis-open.org/commi
 "... is an XML-based framework for communicating user authentication, entitlement, and attribute
 information. As its name suggests, SAML allows business entities to make assertions regarding
 the identity, attributes, and entitlements of a subject (an entity that is often a human user)
-to other entities, such as a partner company or another enterprise application.
+to other entities, such as a partner company or another enterprise application."
 
 ## SANS Institute
 

--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -86,6 +86,12 @@ categories:
 
 Select Cobalt employees may be assigned as administrators, as _Cobalt Staff_.
 
+You can review a list of permissions associated with each organization role in the following
+article: [What do the user roles mean?](https://cobaltio.zendesk.com/hc/en-us/articles/360057093472-What-do-the-user-roles-mean-).
+
+<!-- Per https://zombie.atlassian.net/browse/DOCS-5 I should add info from an internal
+spreadsheet, but need to find pull code in Hugo -->
+
 ### Org Member
 
 An _Org Member_ is a user of the Cobalt App who can create an [asset](#asset) or a
@@ -94,9 +100,16 @@ If allowed by their {{% ptaas-tier %}}, they can also manage integration with Ji
 
 ### Org Owner
 
-An _Org Owner_ can also add/remove the users of their choice, by their email addresses, as
-_Org Owner_ or _Org Member_. They can also manage the [Org Members](#org-member) assigned to a
-specific pentest. If allowed by their {{% ptaas-tier %}}, they can also manage
+An _Org Owner_ is the administrator for a customer organization within the Cobalt app. As such,
+they can:
+
+- Add/remove the users of their choice, by their email addresses, as an _Org Member_ or a
+  _PT Team Member_.
+- View collaborators, the members of their pentest team. That team includes 
+  - _PT Team Members_
+  - _PT Lead_
+  - _PT Pentester_ (when applicable)
+- If allowed by their {{% ptaas-tier %}}, they can also manage
 [SAML](#security-assertion-markup-language) settings for the users in their organization.
 
 ### PT Team Member

--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -81,9 +81,8 @@ When using the Cobalt UI, you may encounter a variety of different users, in the
 categories:
 
 - Organization Roles: If you're a Cobalt customer, you may be an `Org Owner`, `Org Member`, or
-  a `PT Team Member`..
+  a `PT Team Member`.
 - Pentester Roles: If you're a Cobalt pentester, you may be a `PT Pentester` or a `PT Lead`.
-  `Pentest Lead`.
 
 Select Cobalt employees may be assigned as administrators, as `Cobalt Staff`.
 
@@ -98,7 +97,7 @@ If allowed by their {{% ptaas-tier %}}, they can also manage integration with Ji
 An `Org Owner` can also add/remove the users of their choice, by their email addresses, as
 `Org Owner` or `Org Member`. They can also manage the [Org Members](#org-member) assigned to a
 specific pentest. If allowed by their {{% ptaas-tier %}}, they can also manage
-[SAML](#security-assertion-markup-language-saml) settings for the users in their organization.
+[SAML](#security-assertion-markup-language) settings for the users in their organization.
 
 ### PT Team Member
 
@@ -112,7 +111,7 @@ an asset. When applicable, the `PT Lead` also drafts the [pentest report](#pente
 
 ### PT Pentester
 
-A `PT Pentester` is a Cobalt pentester whose participating in testing an asset.
+A `PT Pentester` is a Cobalt pentester whose testing a specific asset.
 
 ### Cobalt Staff
 
@@ -253,7 +252,14 @@ Contrast with [mitigate](#mitigate). This reflects how we use **remediate** at
 Cobalt, and differs slightly from the NIST definition of 
 [remediation](https://csrc.nist.gov/glossary/term/remediation).
 
-## Security Assertion Markup Language (SAML)
+## Security Assertion Markup Language
+
+As defined by the Organization for the Advancement of Structured Information Standards (OASIS),
+the [Security Assertion Markup Language (SAML)](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=security)
+"... is an XML-based framework for communicating user authentication, entitlement, and attribute
+information. As its name suggests, SAML allows business entities to make assertions regarding
+the identity, attributes, and entitlements of a subject (an entity that is often a human user)
+to other entities, such as a partner company or another enterprise application.
 
 ## SANS Institute
 

--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -80,8 +80,11 @@ released in 2021.
 When using the Cobalt UI, you may encounter a variety of different users, in the following
 categories:
 
-- Organization Roles: If you're a Cobalt customer, you may be an _Org Owner_, _Org Member_, or
-  a _PT Team Member_.
+- Organization Roles: If you're a Cobalt customer, your account may have one of the following roles:
+  - Organization Owner: Also known as an _Org Owner_
+  - Organization Member: Also known as an _Org Member_
+  - Pentest Team Member: Also known as a _PT Team Member_
+
 - Pentester Roles: If you're a Cobalt pentester, you may be a _PT Pentester_ or a _PT Lead_.
 
 Select Cobalt employees may be assigned as administrators, as _Cobalt Staff_.
@@ -92,13 +95,13 @@ article: [What do the user roles mean?](https://cobaltio.zendesk.com/hc/en-us/ar
 <!-- Per https://zombie.atlassian.net/browse/DOCS-5 I should add info from an internal
 spreadsheet, but need to find pull code in Hugo -->
 
-### Org Member
+### Organization Member
 
 An _Org Member_ is a user of the Cobalt App who can create an [asset](#asset) or a
 [pentest](#pentest). That user can also see the pentesters who are working on their asset.
 If allowed by their {{% ptaas-tier %}}, they can also manage integration with Jira and GitHub.
 
-### Org Owner
+### Organization Owner
 
 An _Org Owner_ is the administrator for a customer organization within the Cobalt app. As such,
 they can:
@@ -112,17 +115,17 @@ they can:
 - If allowed by their {{% ptaas-tier %}}, they can also manage
 [SAML](#security-assertion-markup-language) settings for the users in their organization.
 
-### PT Team Member
+### Pentest Team Member
 
 A _PT Team Member_ is a customer representative during a pentest. That user can review and
 respond to each [finding](#finding) identified by a Cobalt pentester.
 
-### PT Lead
+### Pentest Lead
 
 A _PT Lead_ is a Cobalt pentester who leads other Cobalt pentesters in their efforts to test
 an asset. When applicable, the _PT Lead_ also drafts the [pentest report](#pentest-report).
 
-### PT Pentester
+### Pentester
 
 A _PT Pentester_ is a Cobalt pentester whose working with a _PT Lead_ to test a specific asset.
 
@@ -269,10 +272,7 @@ Cobalt, and differs slightly from the NIST definition of
 
 As defined by the Organization for the Advancement of Structured Information Standards (OASIS),
 the [Security Assertion Markup Language (SAML)](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=security)
-"... is an XML-based framework for communicating user authentication, entitlement, and attribute
-information. As its name suggests, SAML allows business entities to make assertions regarding
-the identity, attributes, and entitlements of a subject (an entity that is often a human user)
-to other entities, such as a partner company or another enterprise application."
+SAML is an XML-based framework for communicating user authentication, entitlement, and attribute information. 
 
 ## SANS Institute
 
@@ -294,7 +294,7 @@ A User Role specifies the permissions or privileges associated with a user. Comm
 - Full User
 - Guest
 
-This is not a comprehensive list. When scoping an Asset, include a complete list of user roles.
+When scoping an Asset, include a complete list of user roles.
 If you miss a user role, you may sacrifice quality in penetration testing. 
 
 ## Vulnerability

--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -80,38 +80,38 @@ released in 2021.
 When using the Cobalt UI, you may encounter a variety of different users, in the following
 categories:
 
-- Organization Roles: If you're a Cobalt customer, you may be an `Org Owner`, `Org Member`, or
-  a `PT Team Member`.
-- Pentester Roles: If you're a Cobalt pentester, you may be a `PT Pentester` or a `PT Lead`.
+- Organization Roles: If you're a Cobalt customer, you may be an _Org Owner_, _Org Member_, or
+  a _PT Team Member_.
+- Pentester Roles: If you're a Cobalt pentester, you may be a _PT Pentester_ or a _PT Lead_.
 
-Select Cobalt employees may be assigned as administrators, as `Cobalt Staff`.
+Select Cobalt employees may be assigned as administrators, as _Cobalt Staff_.
 
 ### Org Member
 
-An `Org Member` is a user of the Cobalt App who can create an [asset](#asset) or a
+An _Org Member_ is a user of the Cobalt App who can create an [asset](#asset) or a
 [pentest](#pentest). That user can also see the pentesters who are working on their asset.
 If allowed by their {{% ptaas-tier %}}, they can also manage integration with Jira and GitHub.
 
 ### Org Owner
 
-An `Org Owner` can also add/remove the users of their choice, by their email addresses, as
-`Org Owner` or `Org Member`. They can also manage the [Org Members](#org-member) assigned to a
+An _Org Owner_ can also add/remove the users of their choice, by their email addresses, as
+_Org Owner_ or _Org Member_. They can also manage the [Org Members](#org-member) assigned to a
 specific pentest. If allowed by their {{% ptaas-tier %}}, they can also manage
 [SAML](#security-assertion-markup-language) settings for the users in their organization.
 
 ### PT Team Member
 
-A `PT Team Member` is a customer representative during a pentest. That user can review and
+A _PT Team Member_ is a customer representative during a pentest. That user can review and
 respond to each [finding](#finding) identified by a Cobalt pentester.
 
 ### PT Lead
 
-A `PT Lead` is a Cobalt pentester who leads other Cobalt pentesters in their efforts to test
-an asset. When applicable, the `PT Lead` also drafts the [pentest report](#pentest-report).
+A _PT Lead_ is a Cobalt pentester who leads other Cobalt pentesters in their efforts to test
+an asset. When applicable, the _PT Lead_ also drafts the [pentest report](#pentest-report).
 
 ### PT Pentester
 
-A `PT Pentester` is a Cobalt pentester whose testing a specific asset.
+A _PT Pentester_ is a Cobalt pentester whose working with a _PT Lead_ to test a specific asset.
 
 ### Cobalt Staff
 


### PR DESCRIPTION
This PR adds several definitions to the [Glossary](https://developer.cobalt.io/getting-started/glossary/).

For a "build" of the change, navigate to https://deploy-preview-119--cobalt-docs.netlify.app/getting-started/glossary/#cobalt-users . (While glossaries are normally set up in alphabetical order, I think it makes sense to group these types of Cobalt users together -- until I have a separate page that describes functionality for each user type, which is _probably_ beyond the scope of a Getting Started Guide. IOW, this PR is an MVC.) 

Based on the permissions, I've also added a definition for SAML, build here: https://deploy-preview-119--cobalt-docs.netlify.app/getting-started/glossary/#security-assertion-markup-language

FYI, I'm also using these definitions to help define UI copy for Adding/Removing Users from orgs (DOCS-109). So the UI text I recommend in that issue depends at least in part on the definitions that we agree to here.