### PR TITLE
[DOCS-122] Update link to pentest tier definitions

### DIFF
--- a/layouts/shortcodes/ptaas-tier.md
+++ b/layouts/shortcodes/ptaas-tier.md
@@ -1,1 +1,1 @@
-[PtaaS Tier](https://cobaltio.zendesk.com/hc/en-us/articles/4408839706132-Cobalt-PtaaS-Tiers)
+[PtaaS Tier](https://www.cobalt.io/pentest-pricing)


### PR DESCRIPTION
Yogi, since you removed the functionality associated with each tier from the [Zendesk article](https://cobaltio.zendesk.com/hc/en-us/articles/4408839706132-Cobalt-PtaaS-Tiers), I think I need to move the link to our Pricing and Packaging URL (https://www.cobalt.io/pentest-pricing)

If you're interested, I call this text snippet in different doc locations with the `{{% ptaas-tier %}}` variable.