### PR TITLE
NO-TICKET: Remove the read-only statement from docs

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -44,7 +44,7 @@ Once connected, you'll have access to more support articles.
 
 ## API Documentation
 
-Cobalt has a read-only [RESTful API](https://docs.cobalt.io)
+Cobalt has a [RESTful API](https://docs.cobalt.io)
 that allows you to call the following data related to your pentests:
 
 - Organizations


### PR DESCRIPTION
Cobalt API isn't read-only anymore, so this sentence should be updated.