### PR TITLE
[DOCS-94] Update per new credit definitions

### DIFF
--- a/content/en/Getting started/Assets/coverage.md
+++ b/content/en/Getting started/Assets/coverage.md
@@ -30,11 +30,11 @@ You can set your assets to one of five sizes:
 
 | Size        | Default Credits |
 |-------------|:---------------:|
-| Extra Small | 1               |
-| Small       | 2               |
-| Medium      | 3               |
-| Large       | 4               |
-| Extra Large | 5               |
+| Extra Small | 4               |
+| Small       | 8               |
+| Medium      | 12              |
+| Large       | 16              |
+| Extra Large | 20              |
 
 
 ### Coverage Levels and Credits
@@ -62,13 +62,13 @@ or "Extra Light" coverage of an "Extra Small" asset.
 The following table specifies the number of credits associated with
 different asset sizes and coverage levels:
 
-|             | Extra Light | Light | Standard | Large | Extra Large |
-|-------------|:-----------:|:-----:|:--------:|:-----:|:-----------:|
-| Extra Small | X           | X     | 1        | 2     | 3           |
-| Small       | X           | 1     | 2        | 3     | 4           |
-| Medium      | 1           | 2     | 3        | 4     | 5           |
-| Large       | 2           | 3     | 4        | 5     | 6           |
-| Extra Large | 3           | 4     | 5        | 6     | 7           |
+|             | Extra Light | Light | Standard | Large | Extra Large  |
+|-------------|:-----------:|:-----:|:--------:|:-----:|:------------:|
+| Extra Small | X           | X     | 4        | 8     | 12           |
+| Small       | X           | 4     | 8        | 12    | 16           |
+| Medium      | 4           | 8     | 12       | 16    | 20           |
+| Large       | 8           | 12    | 16       | 20    | 24           |
+| Extra Large | 12          | 16    | 20       | 24    | 28           |
 
 ### Pentest Reports
 

--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -282,6 +282,8 @@ A summary of all vulnerability reports, including observations on positive secur
 
 Within Cobalt, this is also known as a Report or a Final Report.
 
+{{% min-credits-report %}}
+
 ## Remediate
 
 To fix a vulnerability identified by a pentest or incident report. Examples:

--- a/layouts/shortcodes/min-credits-report.md
+++ b/layouts/shortcodes/min-credits-report.md
@@ -1,2 +1,2 @@
-We'll write a report for pentests with at least two (2) credits
-<!-- Change for the new credit implementation on May 31 -->
+We'll write a report for pentests with at least four (4) credits
+<!-- Change for the new credit implementation on May 31, 2022 -->

--- a/layouts/shortcodes/min-credits-report.md
+++ b/layouts/shortcodes/min-credits-report.md
@@ -1,2 +1,2 @@
-We'll write a report for pentests with at least four (4) credits
+We'll write a report for pentests with at least eight (8) credits
 <!-- Change for the new credit implementation on May 31, 2022 -->

--- a/layouts/shortcodes/pentest-report-requirements.html
+++ b/layouts/shortcodes/pentest-report-requirements.html
@@ -1,3 +1,3 @@
-If you want a pentest report, you generally must set up a test of at least five (5) credits. 
+If you want a pentest report, you generally must set up a test of at least eight (8) credits. 
 If you've set up a pentest with fewer credits, you'll still have access to the non-report
 items listed in [Pentest Expectations](https://developer.cobalt.io/getting-started/what-to-expect/).

--- a/layouts/shortcodes/pentest-report-requirements.html
+++ b/layouts/shortcodes/pentest-report-requirements.html
@@ -1,3 +1,3 @@
-If you want a pentest report, you generally must set up a test of at least two (2) credits. 
-If you have a one (1) credit pentest, you'll still have access to the non-report
+If you want a pentest report, you generally must set up a test of at least four (4) credits. 
+If you've set up a pentest with fewer credits, you'll still have access to the non-report
 items listed in [Pentest Expectations](https://developer.cobalt.io/getting-started/what-to-expect/).

--- a/layouts/shortcodes/pentest-report-requirements.html
+++ b/layouts/shortcodes/pentest-report-requirements.html
@@ -1,3 +1,3 @@
-If you want a pentest report, you generally must set up a test of at least four (4) credits. 
+If you want a pentest report, you generally must set up a test of at least five (5) credits. 
 If you've set up a pentest with fewer credits, you'll still have access to the non-report
 items listed in [Pentest Expectations](https://developer.cobalt.io/getting-started/what-to-expect/).


### PR DESCRIPTION
Do not merge until at least late May 31

@yogipetkar This should change everything in our product docs.
Unknown: are we still planning to provide a "Simple" report for 4-7 credits, cc @TheInstaGrahame 

You'll see the proposed changes in the build:

- https://deploy-preview-130--cobalt-docs.netlify.app/getting-started/assets/coverage/
- Each of the (6) methodologies pages below https://deploy-preview-130--cobalt-docs.netlify.app/getting-started/pentest-objectives/methodologies/ 
- https://deploy-preview-130--cobalt-docs.netlify.app/getting-started/checklist/
- https://deploy-preview-130--cobalt-docs.netlify.app/getting-started/glossary/#pentest-report