### PR TITLE
[DOCS-146] Credit GitLab for Their File with Spelling Exceptions

### DIFF
--- a/styles/cobalt/spelling-exceptions.txt
+++ b/styles/cobalt/spelling-exceptions.txt
@@ -872,3 +872,5 @@ Zendesk
 ZenTao
 zsh
 Zstandard
+
+<!--This file was created by [GitLab](https://about.gitlab.com/), licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/). We modified the file content to include Cobalt spelling exceptions.-->


### PR DESCRIPTION
@mjang I'm not sure if it's the right way to credit third parties. I checked some examples from other companies. Please let me know if this should look different.