### PR TITLE
[DOCS-166] Add guidance and a template for pentester writers

### DIFF
--- a/content/en/BestPractices/style_suggestions.md
+++ b/content/en/BestPractices/style_suggestions.md
@@ -16,16 +16,18 @@ While you don't need to define common technical concepts like _domain name_ and
 _IP address_, we recommend that you use links to help define more complex terms
 like [Server Side Request Forgery](https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/).
 
-To promote readability, use the following checklist. 
+To promote readability, use the following checklist:
 
 - Write in plain English. Provide brief descriptions for technical terms that
   our audience of developers may not know.
 - Stay positive. Avoid words like `don't` or `can't`. Readers frequently miss
   the `not` in a sentence.
+- Consider using our implementation of [Vale](../../../GrammarLinter.md). When
+  integrated with your IDE, it highlights writing styles that we want you to
+follow.
 
 - Keep your sentences relatively short. Our implementation of
-  [Vale](../../../GrammarLinter.md)
-discourages the use of sentences of more than 28 words.
+  [Vale](../../../GrammarLinter.md) discourages the use of sentences of more than 28 words.
 - Use active voice and the present tense. Examples:
   - Run the _ps_ command.
   - Include a second factor for authentication.

--- a/content/en/BestPractices/style_suggestions.md
+++ b/content/en/BestPractices/style_suggestions.md
@@ -12,6 +12,10 @@ what to do (and what not to do) to secure their systems.
 Our readers are typically not English majors. Our concepts are already complex.
 It helps our readers if you use the simplest possible language.
 
+While you don't need to define common technical concepts like _domain name_ and
+_IP address_, we recommend that you use links to help define more complex terms
+like [Server Side Request Forgery](https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/).
+
 To promote readability, use the following checklist. 
 
 - Write in plain English. Provide brief descriptions for technical terms that
@@ -19,15 +23,16 @@ To promote readability, use the following checklist.
 - Stay positive. Avoid words like `don't` or `can't`. Readers frequently miss
   the `not` in a sentence.
 
-- Keep your sentences relatively short. Our implementation of [Vale](#add-link)
+- Keep your sentences relatively short. Our implementation of
+  [Vale](../../../GrammarLinter.md)
 discourages the use of sentences of more than 28 words.
 - Use active voice and the present tense. Examples:
   - Run the _ps_ command.
-  - Include at least a second factor for authentication.
+  - Include a second factor for authentication.
   - Encrypt the system with a ECDSA key.
 
-- Exception: it is OK to use passive voice for definitions. Examples:
-  - An example for a domain name is example.com.
+- Exception: it is OK to use passive voice for definitions. Example:
+  - A [Pentest Team Member](https://developer.cobalt.io/getting-started/glossary/#pentest-team-member) is a customer (organization) representative during a specific pentest.
 
 - In lists, use the serial comma (also known as the Oxford comma)
 

--- a/content/en/BestPractices/style_suggestions.md
+++ b/content/en/BestPractices/style_suggestions.md
@@ -1,0 +1,35 @@
+# Style Guidance for Pentester Writers
+
+We're looking for product documentation, What you write here is not a pentest
+report, but a guide primarily for developers who want to improve the security of
+their products. 
+
+When you write your article, remember your readers. They need your help learning
+what to do (and what not to do) to secure their systems.
+
+## Readability
+
+Our readers are typically not English majors. Our concepts are already complex.
+It helps our readers if you use the simplest possible language.
+
+To promote readability, use the following checklist. 
+
+- Write in plain English. Provide brief descriptions for technical terms that
+  our audience of developers may not know.
+- Stay positive. Avoid words like `don't` or `can't`. Readers frequently miss
+  the `not` in a sentence.
+
+- Keep your sentences relatively short. Our implementation of [Vale](#add-link)
+discourages the use of sentences of more than 28 words.
+- Use active voice and the present tense. Examples:
+  - Run the _ps_ command.
+  - Include at least a second factor for authentication.
+  - Encrypt the system with a ECDSA key.
+
+- Exception: it is OK to use passive voice for definitions. Examples:
+  - An example for a domain name is example.com.
+
+- In lists, use the serial comma (also known as the Oxford comma)
+
+For more information, see the Google Developer Style Guide discussion on 
+[voice and tone](https://developers.google.com/style/tone).

--- a/content/en/BestPractices/template.md
+++ b/content/en/BestPractices/template.md
@@ -1,0 +1,56 @@
+---
+title: "<Substitute your title>"
+linkTitle: "<Substitute a possibly shorter title>"
+# Change this weight, based on where it should go in the "Best Practices"
+# section
+weight: 600
+# The `toc_hide` entry hides the link from the menu. The content still available
+# at <URL>/bestpractices/. We'll remove the entry when we publish your work
+toc_hide: true
+description: >
+  <Substitute the description of your choice.>
+---
+
+<!-- For the title:
+
+- If you want to address the OWASP item in general, use the name of the OWASP Top 10 item
+- If your article is more specific, make sure it "stands out". We may have
+  suggestions to help. -->
+
+{{% pageinfo %}}
+<Substitute a "catchy" summary, something like "You can protect your code from X
+with <some technique.">
+{{% /pageinfo %}}
+
+If you're confident in your ability to organize written information, you're welcome to ignore this template. Otherwise, we present this template as one way to organize your work.
+
+## Description
+
+Introduce your topic to our audience of developers. While they'll certainly understand concepts like hostnames and IP addresses, you may need to explain security-specific concepts like ABAC and SELinux.
+
+## Examples
+
+Describe how problems might happen. Include consequences. When possible, incorporate code samples and commands. Developers are known to focus on code samples and commands as patterns (and anti-patterns).
+
+## Prevent <Name of Problem>
+
+Address each example. If you've included code samples and commands earlier, include related samples to illustrate "good" patterns.
+
+You could also set up a table of "bad" and "good" patterns.
+
+## Alternative Solution 
+
+You could combine Examples and Prevention in different scenarios; some authors have organized articles with the following outline:
+
+- Description
+- Scenarios
+  - Scenario 1 (with some descriptive title)
+    - Example (with code sample)
+    - Prevention (with code sample)
+  - Scenario 2
+  - ...
+- Commentary
+
+## References
+
+Many readers want to read more about security. You're welcome to add references to other articles related to what you've written, such as those you've used to research your work. To avoid plagiarism, do reference and quote content that you use from others.

--- a/content/en/BestPractices/template.md
+++ b/content/en/BestPractices/template.md
@@ -12,7 +12,7 @@ description: >
 ---
 
 We include this template for your convenience. You're welcome to copy this file
-(and change the file name) to help you write your article. Examine the source
+(and change the filename) to help you write your article. Examine the source
 code for this article, as you'll see some help text in comments.
 
 <!-- For the title:

--- a/content/en/BestPractices/template.md
+++ b/content/en/BestPractices/template.md
@@ -11,6 +11,10 @@ description: >
   <Substitute the description of your choice.>
 ---
 
+We include this template for your convenience. You're welcome to copy this file
+(and change the file name) to help you write your article. Examine the source
+code for this article, as you'll see some help text in comments.
+
 <!-- For the title:
 
 - If you want to address the OWASP item in general, use the name of the OWASP Top 10 item
@@ -32,13 +36,13 @@ Introduce your topic to our audience of developers. While they'll certainly unde
 
 Describe how problems might happen. Include consequences. When possible, incorporate code samples and commands. Developers are known to focus on code samples and commands as patterns (and anti-patterns).
 
-## Prevent <Name of Problem>
+## Prevention <or Prevent Name of Problem>
 
 Address each example. If you've included code samples and commands earlier, include related samples to illustrate "good" patterns.
 
 You could also set up a table of "bad" and "good" patterns.
 
-## Alternative Solution 
+## Alternatives
 
 You could combine Examples and Prevention in different scenarios; some authors have organized articles with the following outline:
 


### PR DESCRIPTION
As discussed during our last [internal] content creators meeting, I've laid out a template and a "style sheet" of sorts. I'd appreciate your review.

I've also "hidden" these markdown files from publishing, so you won't see them. If you want to see a "copy as built", you could review the relevant files in the [`BestPractices/` subdirectory](https://github.com/cobalthq/cobalt-product-public-docs/tree/DOCS-166_guidance_for_pentester_writers/content/en/BestPractices) for the branch.