### PR TITLE
Revert change to asset in substitutions.yml file

### DIFF
--- a/styles/cobalt/Substitutions.yml
+++ b/styles/cobalt/Substitutions.yml
@@ -11,8 +11,6 @@ link: https://about.gitlab.com/handbook/communication/#top-misused-terms
 level: error
 ignorecase: true
 swap:
-  asset: Asset
-  assets: Assets
   Cobalt App: Cobalt app
   codequality: code quality
   Customer [Pp]ortal: Customers Portal


### PR DESCRIPTION
@ana-dashuk-cobalt 

I think I made a mistake when I suggested that we should always capitalize `asset`. I’ve looked at what competitors do in their literature ([snyk.io](http://snyk.io/), [rapid7.com](http://rapid7.com/), [hackerone.com](http://hackerone.com/)) and they all do not capitalize asset.