### PR TITLE
[NO-TICKET] Update retest description with dependency on PtaaS Tier

### DIFF
--- a/content/en/Getting started/What to Expect/_index.md
+++ b/content/en/Getting started/What to Expect/_index.md
@@ -47,7 +47,7 @@ results. Here's what you can expect:
      - Pending Fix, when your developers are remediating the finding.
      - Ready for Re-Test, assumes that your developers have fixed the issue, and you're ready
        for our pentesters to validate your fix. Retesting may depend on
-       your {{% ptaas-tier % }}.
+       your {{% ptaas-tier %}}.
      - Accepted Risk, when you've determined that the finding is either not critical,
        or is beyond your control.
        For more information, see the following blog post on [Accepted Risk](https://cobalt.io/blog/explain-accepted-risk-in-a-few-easy-steps).

--- a/content/en/Getting started/What to Expect/_index.md
+++ b/content/en/Getting started/What to Expect/_index.md
@@ -46,7 +46,8 @@ results. Here's what you can expect:
 
      - Pending Fix, when your developers are remediating the finding.
      - Ready for Re-Test, assumes that your developers have fixed the issue, and you're ready
-       for our pentesters to validate your fix.
+       for our pentesters to validate your fix. Retesting may depend on
+       your {{% ptaas-tier % }}.
      - Accepted Risk, when you've determined that the finding is either not critical,
        or is beyond your control.
        For more information, see the following blog post on [Accepted Risk](https://cobalt.io/blog/explain-accepted-risk-in-a-few-easy-steps).


### PR DESCRIPTION
@ana-dashuk-cobalt as I go through our plan to convert Zendesk articles, I realized that, for "retesting," we do not include any reference to the PtaaS tier.