### PR TITLE
[DOCS-168] Pentester Updates

### DIFF
--- a/content/en/Getting started/What to Expect/_index.md
+++ b/content/en/Getting started/What to Expect/_index.md
@@ -53,7 +53,7 @@ results. Here's what you can expect:
        For more information, see the following blog post on [Accepted Risk](https://cobalt.io/blog/explain-accepted-risk-in-a-few-easy-steps).
 
 1. You can continue to collaborate with pentesters:
-   - On the **Pentester Updates** tab
+   - On the **Pentester Updates** tab of the pentest page
    - In the Slack channel. We keep the channel open until you've set each finding to:
       - Accepted Risk
       - Fixed

--- a/content/en/Getting started/What to Expect/_index.md
+++ b/content/en/Getting started/What to Expect/_index.md
@@ -16,17 +16,17 @@ results. Here's what you can expect:
 
 1. Once you've finished setting up a pentest, select **Pentests** in the left-hand
    pane. You should see your pentest listed, with an _In Review_ label.
-1. Select your pentest. You should see a link to a Slack channel, dedicated for your pentest.
-1. Add the colleagues of your choice to the Slack channel. Choose colleagues who can
-   benefit from direct communication with our pentesters.
 1. We'll select the best available testers before the start of the pentest. The time we need
    depends on your {{% ptaas-tier %}} and any special requirements you have.
-   - As soon as we've selected your pentesters, and have moved your pentest from
-     _In Review_ to _Planned_, you'll see them in your Slack channel.
-1. You may get questions from your pentesters in Slack. You can also elaborate
-   on your requirements in that same channel.
-1. As our pentesters analyze your asset, they'll add updates frequently in your
-   Slack channel. If they discover vulnerabilities ("findings"), you can start
+1. Once we start the pentest, you’ll start getting updates from pentesters. You can communicate with pentesters:
+   - On the **Pentester Updates** tab of the pentest page
+   - In a Slack channel dedicated for your pentest. You should see a link to the Slack channel on the pentest page next to the pentest status.
+      - Add the colleagues of your choice to the Slack channel. Choose colleagues who can benefit from direct communication with our pentesters.
+      - As soon as we’ve moved your pentest from _In Review_ to _Planned_, you’ll see your pentesters in the Slack channel.
+1. You may get questions from your pentesters. You can also elaborate
+   on your requirements for the pentest.
+   - You'll get in-app and email notifications for each update from pentesters.
+1. As our pentesters analyze your asset, they'll add updates frequently. If they discover vulnerabilities ("findings"), you can start
    remediating before the pentest is complete.
    
    Here's an example finding as discussed in a Slack pentest channel.
@@ -35,12 +35,12 @@ results. Here's what you can expect:
 
    {{% alert title="Note" color="note" %}}
    As our pentesters share the vulnerabilities they find in "real-time," you can
-   start remediating your code before you see a Pentest report.
+   start remediating your code before you see a pentest report.
    {{% /alert %}}
 
 1. Once the pentest is complete, we move your pentest from _Planned_ to _Remediation_.
 1. You can start assessing all discovered vulnerabilities. In the Cobalt app, navigate
-   to **Pentests**. Select your pentest, and navigate to the Findings tab.
+   to **Pentests**. Select your pentest, and navigate to the **Findings** tab.
    - Scroll down until you see **Activity**. Depending on your assessment, you can
      set the finding to one of the following states:
 
@@ -52,14 +52,14 @@ results. Here's what you can expect:
        or is beyond your control.
        For more information, see the following blog post on [Accepted Risk](https://cobalt.io/blog/explain-accepted-risk-in-a-few-easy-steps).
 
-1. We keep the Slack channel open until you've set each finding to:
+1. You can continue to collaborate with pentesters:
+   - On the **Pentester Updates** tab
+   - In the Slack channel. We keep the channel open until you've set each finding to:
+      - Accepted Risk
+      - Fixed
 
-   - Accepted Risk
-   - Fixed
-
-   If you need access to the archived channel, contact your Customer Success Manager
-   or support@cobalt.io.
-1. If you've purchased a qualifying {{% ptaas-tier %}}, you can customize your Pentest report.
+   If you need access to the archived Slack channel, contact your Customer Success Manager or support@cobalt.io.
+1. If you've purchased a qualifying {{% ptaas-tier %}}, you can customize your pentest report.
    However, we report _all_ findings. For more information, see the following blog post
    on how you can [Customize Your Pentest
    Reports](https://cobalt.io/blog/cobalt-platform-deep-dive-customize-your-pentest-reports-per-your-needs).

--- a/content/en/Getting started/What to Expect/_index.md
+++ b/content/en/Getting started/What to Expect/_index.md
@@ -18,9 +18,9 @@ results. Here's what you can expect:
    pane. You should see your pentest listed, with an _In Review_ label.
 1. We'll select the best available testers before the start of the pentest. The time we need
    depends on your {{% ptaas-tier %}} and any special requirements you have.
-1. Once we start the pentest, you’ll start getting updates from pentesters. You can communicate with pentesters:
+1. Once we start the pentest, you’ll start getting updates from pentesters:
    - On the **Pentester Updates** tab of the pentest page
-   - In a Slack channel dedicated for your pentest. You should see a link to the Slack channel on the pentest page next to the pentest status.
+   - In a Slack channel dedicated for your pentest where you can communicate with pentesters. You should see a link to the Slack channel on the pentest page next to the pentest status.
       - Add the colleagues of your choice to the Slack channel. Choose colleagues who can benefit from direct communication with our pentesters.
       - As soon as we’ve moved your pentest from _In Review_ to _Planned_, you’ll see your pentesters in the Slack channel.
 1. You may get questions from your pentesters. You can also elaborate
@@ -52,12 +52,9 @@ results. Here's what you can expect:
        or is beyond your control.
        For more information, see the following blog post on [Accepted Risk](https://cobalt.io/blog/explain-accepted-risk-in-a-few-easy-steps).
 
-1. You can continue to collaborate with pentesters:
-   - On the **Pentester Updates** tab of the pentest page
-   - In the Slack channel. We keep the channel open until you've set each finding to:
-      - Accepted Risk
-      - Fixed
-
+1. We keep the Slack channel open until you've set each finding to:
+   - Accepted Risk
+   - Fixed
    If you need access to the archived Slack channel, contact your Customer Success Manager or support@cobalt.io.
 1. If you've purchased a qualifying {{% ptaas-tier %}}, you can customize your pentest report.
    However, we report _all_ findings. For more information, see the following blog post


### PR DESCRIPTION
@mjang 
I need to add Roshan as a reviewer for this PR, but I can't find him on the list of users.

Update: Roshan doesn't have a GitHub account.

The functionality is scheduled for release on August 17. I'm also trying to get a screenshot for a message on the **Pentester Updates** tab from the CX-Collaboration team.

Update: Since they don't have good screenshots without sensitive data, I decided not to include it.