### PR TITLE
[DOCS-159] Remove option for consolidated page prints

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -71,7 +71,7 @@ enableGitInfo = true
 # Everything below this are Site Params
 
 [outputs]
-section = ["HTML", "print", "RSS"]
+section = ["HTML", "RSS"]
 
 [params]
 copyright = "Cobalt Labs"


### PR DESCRIPTION
If this eliminates the `_print` pages, as suggested by my online research, this should work.