### PR TITLE
[DOCS-290] Update docsy theme hash

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "public"
-command = "cd themes/docsy && git submodule update -f --init && git checkout f82dd5e && cd ../..   && hugo"   
+command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"   
   
 [build.environment]
 HUGO_VERSION = "0.104.0"


### PR DESCRIPTION
@ana-dashuk-cobalt I forget why I added `git checkout f82dd5e &&` to the Doscy line in netlify.toml. (IIRC, it was a workaround for something.)

The CI failures in PRs like https://github.com/cobalthq/cobalt-product-public-docs/pull/186 and #187 tell me that line's now a problem.

I hope this PR addresses the problem... (I'll have to rebase against those PRs to be sure.)