### PR TITLE
[DOCS-190] Free Retesting Duration

### DIFF
--- a/content/en/Getting started/what-to-expect.md
+++ b/content/en/Getting started/what-to-expect.md
@@ -40,7 +40,7 @@ results. Here's what you can expect:
 1. Once the pentest is complete, we move your pentest from _Planned_ to _Remediation_.
 1. You can start assessing all discovered vulnerabilities. In the Cobalt app, navigate
    to **Pentests**. Select your pentest, and navigate to the **Findings** tab.
-   - Find the **Status** list. Depending on your assessment, you can
+   - Find the **State** list. Depending on your assessment, you can
      set the finding to one of the following states:
 
      - **Pending Fix**, when your developers are remediating the finding.

--- a/content/en/Getting started/what-to-expect.md
+++ b/content/en/Getting started/what-to-expect.md
@@ -40,17 +40,19 @@ results. Here's what you can expect:
 1. Once the pentest is complete, we move your pentest from _Planned_ to _Remediation_.
 1. You can start assessing all discovered vulnerabilities. In the Cobalt app, navigate
    to **Pentests**. Select your pentest, and navigate to the **Findings** tab.
-   - Scroll down until you see **Activity**. Depending on your assessment, you can
+   - Find the **Status** list on the right of the page. Depending on your assessment, you can
      set the finding to one of the following states:
 
-     - Pending Fix, when your developers are remediating the finding.
-     - Ready for Retest, assumes that your developers have fixed the issue, and you're ready
-       for our pentesters to validate your fix. Retesting may depend on
+     - **Pending Fix**, when your developers are remediating the finding.
+     - **Ready for Retest**, assumes that your developers have fixed the issue, and you're ready
+       for our pentesters to validate your fix. Free retesting duration depends on
        your {{% ptaas-tier %}}.
-     - Accepted Risk, when you've determined that the finding is either not critical,
+       - The timeline for retesting starts after your pentest end date within an active contract. Mark your findings as **Ready for Retest** at least 10 days before your contract ends.
+       - We change the finding status and notify the pentester who posted the finding to retest the issue. If the pentester can’t reproduce the issue, they mark the finding as **Fixed**. Otherwise, they change the status back to **Pending Fix** and write a comment explaining why.
+       - Our pentesters complete retesting within seven (7) business days after submission.
+     - **Accepted Risk**, when you've determined that the finding is either not critical,
        or is beyond your control.
        For more information, see the following blog post on [Accepted Risk](https://cobalt.io/blog/explain-accepted-risk-in-a-few-easy-steps).
-
 1. We keep the Slack channel open until you've set each finding to:
    - Accepted Risk
    - Fixed

--- a/content/en/Getting started/what-to-expect.md
+++ b/content/en/Getting started/what-to-expect.md
@@ -48,7 +48,7 @@ results. Here's what you can expect:
        for our pentesters to validate your fix. Free retesting duration depends on
        your {{% ptaas-tier %}}.
        - The timeline for retesting starts after your pentest end date within an active contract. Mark your findings as **Ready for Retest** at least 10 days before your contract ends.
-       - We change the finding status and notify the pentester who posted the finding to retest the issue. If the pentester can’t reproduce the issue, they mark the finding as **Fixed**. Otherwise, they change the status back to **Pending Fix** and write a comment explaining why.
+       - We change the finding state and notify the pentester who posted the finding to retest the issue. If the pentester can’t reproduce the issue, they mark the finding as **Fixed**. Otherwise, they change the status back to **Pending Fix** and write a comment explaining why.
        - Our pentesters complete retesting within seven (7) business days after submission.
      - **Accepted Risk**, when you've determined that the finding is either not critical,
        or is beyond your control.

--- a/content/en/Getting started/what-to-expect.md
+++ b/content/en/Getting started/what-to-expect.md
@@ -40,7 +40,7 @@ results. Here's what you can expect:
 1. Once the pentest is complete, we move your pentest from _Planned_ to _Remediation_.
 1. You can start assessing all discovered vulnerabilities. In the Cobalt app, navigate
    to **Pentests**. Select your pentest, and navigate to the **Findings** tab.
-   - Find the **Status** list on the right of the page. Depending on your assessment, you can
+   - Find the **Status** list. Depending on your assessment, you can
      set the finding to one of the following states:
 
      - **Pending Fix**, when your developers are remediating the finding.

--- a/content/en/Getting started/what-to-expect.md
+++ b/content/en/Getting started/what-to-expect.md
@@ -19,7 +19,7 @@ results. Here's what you can expect:
    depends on your {{% ptaas-tier %}} and any special requirements you have.
 1. Once we start the pentest, you’ll start getting updates from pentesters:
    - On the **Pentester Updates** tab of the pentest page
-   - In a Slack channel dedicated for your pentest where you can communicate with pentesters. You should see a link to the Slack channel on the pentest page next to the pentest status.
+   - In a Slack channel dedicated for your pentest where you can communicate with pentesters. You should see a link to the Slack channel on the pentest page next to the pentest state.
       - Add the colleagues of your choice to the Slack channel. Choose colleagues who can benefit from direct communication with our pentesters.
       - As soon as we’ve moved your pentest from _In Review_ to _Planned_, you’ll see your pentesters in the Slack channel.
 1. You may get questions from your pentesters. You can also elaborate
@@ -48,7 +48,7 @@ results. Here's what you can expect:
        for our pentesters to validate your fix. Free retesting duration depends on
        your {{% ptaas-tier %}}.
        - The timeline for retesting starts after your pentest end date within an active contract. Mark your findings as **Ready for Retest** at least 10 days before your contract ends.
-       - We change the finding state and notify the pentester who posted the finding to retest the issue. If the pentester can’t reproduce the issue, they mark the finding as **Fixed**. Otherwise, they change the status back to **Pending Fix** and write a comment explaining why.
+       - We change the finding state and notify the pentester who posted the finding to retest the issue. If the pentester can’t reproduce the issue, they mark the finding as **Fixed**. Otherwise, they change the state back to **Pending Fix** and write a comment explaining why.
        - Our pentesters complete retesting within seven (7) business days after submission.
      - **Accepted Risk**, when you've determined that the finding is either not critical,
        or is beyond your control.


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Pentest Expectations | https://deploy-preview-198--cobalt-docs.netlify.app/getting-started/what-to-expect/ | Added info about retests to p. 7 > **Ready for Retest**  |

A new guide about retests will be added as part of the SSoT plan.

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.
