### PR TITLE
[DOCS-314] Add sprint 2 pentest contributors

### DIFF
--- a/content/en/BestPractices/_index.md
+++ b/content/en/BestPractices/_index.md
@@ -25,13 +25,13 @@ until we have enough articles to actually organize. -->
 Once we've merged content into this guide, we'll list them in the following table with the
 date of release.
 
-### October 20, 2022
+### October 21, 2022
 
 | Article                                                               | Release Date | Author                |
 |-----------------------------------------------------------------------|--------------|-----------------------|
-| [Prevent Insecure Design in SQL](./secure-design)                     | 2022-10-18   | {{% shashank %}}      |
-| [Protect Your APIs With Rate Limiting](./api-rate-limiting)           | 2022-10-18   | {{% payloadartist %}} |
-| [Prevent Server-Side Template Injections](./prevent-ssti)             | 2022-10-18   | {{% unstabl3 %}}      |
+| [Prevent Insecure Design in SQL](./secure-design)                     | 2022-10-21   | {{% shashank %}}      |
+| [Protect Your APIs With Rate Limiting](./api-rate-limiting)           | 2022-10-21   | {{% payloadartist %}} |
+| [Prevent Server-Side Template Injections](./prevent-ssti)             | 2022-10-21   | {{% unstabl3 %}}      |
 
 ### August 19, 2022
 

--- a/content/en/BestPractices/_index.md
+++ b/content/en/BestPractices/_index.md
@@ -25,11 +25,18 @@ until we have enough articles to actually organize. -->
 Once we've merged content into this guide, we'll list them in the following table with the
 date of release.
 
+### October 20, 2022
+
 | Article                                                               | Release Date | Author                |
 |-----------------------------------------------------------------------|--------------|-----------------------|
 | [Prevent Insecure Design in SQL](./secure-design)                     | 2022-10-18   | {{% shashank %}}      |
 | [Protect Your APIs With Rate Limiting](./api-rate-limiting)           | 2022-10-18   | {{% payloadartist %}} |
-| [Prevent Server-Side Template Injections](./prevent-ssti)             | 2022-10-18   | {{% unstabl3 %}} |
+| [Prevent Server-Side Template Injections](./prevent-ssti)             | 2022-10-18   | {{% unstabl3 %}}      |
+
+### August 19, 2022
+
+| Article                                                               | Release Date | Author                |
+|-----------------------------------------------------------------------|--------------|-----------------------|
 | [Validate User Input](./input-validation)                             | 2022-08-19   | {{% payloadartist %}} |
 | [Prevent Security Misconfiguration](./prevent-security-misconfig)     | 2022-08-19   | {{% shashank %}}      |
 | [Protect Against Server-Side Request Forgery](./protect-against-ssrf) | 2022-08-19   | {{% harsh-bothra %}}  |

--- a/content/en/BestPractices/_index.md
+++ b/content/en/BestPractices/_index.md
@@ -25,11 +25,11 @@ until we have enough articles to actually organize. -->
 Once we've merged content into this guide, we'll list them in the following table with the
 date of release.
 
-| Article                                                              | Release Date | Author                |
-|----------------------------------------------------------------------|--------------|-----------------------|
-| [Validate User Input](./input-validation)                      | 2022-08-19   | {{% payloadartist %}} |
-| [Prevent Security Misconfiguration](./prevent-security-misconfig)              | 2022-08-19   | {{% shashank %}}      |
+| Article                                                               | Release Date | Author                |
+|-----------------------------------------------------------------------|--------------|-----------------------|
+| [Prevent Insecure Design in SQL](./secure-design)                     | 2022-10-18   | {{% shashank %}}      |
+| [Protect Your APIs With Rate Limiting](./api-rate-limiting)           | 2022-10-18   | {{% payloadartist %}} |
+| [Prevent Server-Side Template Injections](./prevent-ssti)             | 2022-10-18   | {{% payloadartist %}} |
+| [Validate User Input](./input-validation)                             | 2022-08-19   | {{% payloadartist %}} |
+| [Prevent Security Misconfiguration](./prevent-security-misconfig)     | 2022-08-19   | {{% shashank %}}      |
 | [Protect Against Server-Side Request Forgery](./protect-against-ssrf) | 2022-08-19   | {{% harsh-bothra %}}  |
-| [Protect Your APIs With Rate Limiting](./api-rate-limiting) | 2022-10-18   | {{% payloadartist %}}  |
-| [Prevent Insecure Design in SQL](./secure-design) | 2022-10-18   | {{% shashank %}}  |
-| [Prevent Server-Side Template Injections](./prevent-ssti) | 2022-10-18   | {{% unstabl3 %}}  |

--- a/content/en/BestPractices/_index.md
+++ b/content/en/BestPractices/_index.md
@@ -29,7 +29,7 @@ date of release.
 |-----------------------------------------------------------------------|--------------|-----------------------|
 | [Prevent Insecure Design in SQL](./secure-design)                     | 2022-10-18   | {{% shashank %}}      |
 | [Protect Your APIs With Rate Limiting](./api-rate-limiting)           | 2022-10-18   | {{% payloadartist %}} |
-| [Prevent Server-Side Template Injections](./prevent-ssti)             | 2022-10-18   | {{% payloadartist %}} |
+| [Prevent Server-Side Template Injections](./prevent-ssti)             | 2022-10-18   | {{% unstabl3 %}} |
 | [Validate User Input](./input-validation)                             | 2022-08-19   | {{% payloadartist %}} |
 | [Prevent Security Misconfiguration](./prevent-security-misconfig)     | 2022-08-19   | {{% shashank %}}      |
 | [Protect Against Server-Side Request Forgery](./protect-against-ssrf) | 2022-08-19   | {{% harsh-bothra %}}  |

--- a/content/en/BestPractices/_index.md
+++ b/content/en/BestPractices/_index.md
@@ -30,4 +30,6 @@ date of release.
 | [Validate User Input](./input-validation)                      | 2022-08-19   | {{% payloadartist %}} |
 | [Prevent Security Misconfiguration](./prevent-security-misconfig)              | 2022-08-19   | {{% shashank %}}      |
 | [Protect Against Server-Side Request Forgery](./protect-against-ssrf) | 2022-08-19   | {{% harsh-bothra %}}  |
-
+| [Protect Your APIs With Rate Limiting](./api-rate-limiting) | 2022-10-18   | {{% payloadartist %}}  |
+| [Prevent Insecure Design in SQL](./secure-design) | 2022-10-18   | {{% shashank %}}  |
+| [Prevent Server-Side Template Injections](./prevent-ssti) | 2022-10-18   | {{% unstabl3 %}}  |

--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,4 +1,0 @@
----
-title: Search Results
-layout: search
----

--- a/layouts/shortcodes/unstabl3.html
+++ b/layouts/shortcodes/unstabl3.html
@@ -1,0 +1,1 @@
+<a href="https://shubhamchaskar.com/">Shubham Chaskar</a>

--- a/layouts/shortcodes/unstabl3.md
+++ b/layouts/shortcodes/unstabl3.md
@@ -1,1 +1,0 @@
-[Shubham Chaskar](https://shubhamchaskar.com/)

--- a/layouts/shortcodes/unstabl3.md
+++ b/layouts/shortcodes/unstabl3.md
@@ -1,0 +1,1 @@
+[Shubham Chaskar](https://shubhamchaskar.com/)


### PR DESCRIPTION
## Changelog

Sprint 2 not yet complete. Including 3 approved articles.

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Best Practices | [[Link]](https://deploy-preview-210--cobalt-docs.netlify.app/bestpractices/) | 3 articles, so far |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{ % asset-categories % }}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.
