### PR TITLE
[DOCS-207] Move pentest methodologies

### DIFF
--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/_index.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/_index.md
@@ -1,9 +1,11 @@
 ---
 title: "Pentest Methodologies"
 linkTitle: "Pentest Methodologies"
-weight: 20
+weight: 10
 description: >
   An overview of available pentest methodologies.
+aliases:
+    - /getting-started/pentest-objectives/methodologies/
 ---
 
 {{% pageinfo %}}

--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/api-methodologies.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/api-methodologies.md
@@ -4,6 +4,8 @@ linkTitle: "API Methodologies"
 weight: 120
 description: >
   Review methodologies for APIs.
+aliases:
+    - /getting-started/pentest-objectives/methodologies/api/
 ---
 
 {{% pageinfo %}}

--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/cloud.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/cloud.md
@@ -4,6 +4,8 @@ linkTitle: "Cloud Pentest Methodologies"
 weight: 140
 description: >
   Review methodologies for Cloud Configurations.
+aliases:
+    - /getting-started/pentest-objectives/methodologies/cloud/
 ---
 
 {{% pageinfo %}}

--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/external-network.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/external-network.md
@@ -4,6 +4,8 @@ linkTitle: "External Network Methodologies"
 weight: 130
 description: >
   Review methodologies for External Networks.
+aliases:
+    - /getting-started/pentest-objectives/methodologies/external-network/
 ---
 
 {{% pageinfo %}}

--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/internal-network.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/internal-network.md
@@ -4,6 +4,8 @@ linkTitle: "Internal Network Methodologies"
 weight: 150
 description: >
   Review methodologies for Internal Networks.
+aliases:
+    - /getting-started/pentest-objectives/methodologies/internal-network/
 ---
 
 {{% pageinfo %}}

--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/mobile.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/mobile.md
@@ -4,6 +4,8 @@ linkTitle: "Mobile Methodologies"
 weight: 110
 description: >
   Review methodologies for Mobile Apps.
+aliases:
+    - /getting-started/pentest-objectives/methodologies/mobile/
 ---
 
 {{% pageinfo %}}

--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/web-methodologies.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/web-methodologies.md
@@ -4,6 +4,8 @@ linkTitle: "Web Methodologies"
 weight: 100
 description: >
   Review pentest objectives for Web Apps.
+aliases:
+    - /getting-started/pentest-objectives/methodologies/web-methodologies/
 ---
 
 {{% pageinfo %}}

--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/_index.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pentest Process"
 linkTitle: "Pentest Process"
-weight: 30
+weight: 20
 description: >
   Learn how Cobalt tests your assets.
 ---

--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/_index.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/_index.md
@@ -1,0 +1,12 @@
+---
+title: "Pentest Process"
+linkTitle: "Pentest Process"
+weight: 30
+description: >
+  Learn how Cobalt tests your assets.
+---
+
+{{% pageinfo %}}
+Cobalt defines a sequence of events which use specific methodologies based on your asset.
+{{% /pageinfo %}}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "devDependencies": {
-        "autoprefixer": "^9.8.6",
+        "autoprefixer": "^9.8.8",
         "postcss-cli": "^7.1.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/google/docsy-example#readme",
   "devDependencies": {
-    "autoprefixer": "^9.8.6",
+    "autoprefixer": "^9.8.8",
     "postcss-cli": "^7.1.2"
   }
 }


### PR DESCRIPTION
## Changelog

- Moved Pentest Methodologies content from Getting Started to Pentest Deep Dive
- Created placeholder _index.md file for Pentest Process
- Included `aliases` to redirect from former location

### Added
| Page                                                                                      | Deploy Preview                                                                                                                                   | Comment                                                                                                                                                   |
|-------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
| content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/web-methodologies.md | [New location](https://deploy-preview-212--cobalt-docs.netlify.app/platform-deep-dive/pentests/pentest-process/methodologies/web-methodologies/) | [Old location (should redirect)](https://deploy-preview-212--cobalt-docs.netlify.app/getting-started/pentest-objectives/methodologies/web-methodologies/) |
| content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/mobile.md            | [New location](https://deploy-preview-212--cobalt-docs.netlify.app/platform-deep-dive/pentests/pentest-process/methodologies/mobile/)            | [Old location (should redirect)](https://deploy-preview-212--cobalt-docs.netlify.app/getting-started/pentest-objectives/methodologies/mobile/)            |
| content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/api.md               | [New location](https://deploy-preview-212--cobalt-docs.netlify.app/platform-deep-dive/pentests/pentest-process/methodologies/api/)               | [Old location (should redirect)](https://deploy-preview-212--cobalt-docs.netlify.app/getting-started/pentest-objectives/methodologies/api/)               |
| content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/external-network.md  | [New location](https://deploy-preview-212--cobalt-docs.netlify.app/platform-deep-dive/pentests/pentest-process/methodologies/external-network/)  | [Old location (should redirect)](https://deploy-preview-212--cobalt-docs.netlify.app/getting-started/pentest-objectives/methodologies/external-network/)  |
| content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/cloud.md             | [New location](https://deploy-preview-212--cobalt-docs.netlify.app/platform-deep-dive/pentests/pentest-process/methodologies/cloud/)             | [Old location (should redirect)](https://deploy-preview-212--cobalt-docs.netlify.app/getting-started/pentest-objectives/methodologies/cloud/)             |
| content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/internal-network.md  | [New location](https://deploy-preview-212--cobalt-docs.netlify.app/platform-deep-dive/pentests/pentest-process/methodologies/internal-network/)  | [Old location (should redirect)](https://deploy-preview-212--cobalt-docs.netlify.app/getting-started/pentest-objectives/methodologies/internal-network/)  |

### Updated

Deleted corresponding content from the getting-started/pentest-objectives/methodologies/ directory

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{ % asset-categories % }}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.
