### PR TITLE
[NO-TICKET] Limit support to GitHub Cloud

### DIFF
--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -169,7 +169,7 @@ In the Cobalt UI, you'll see this user role as "Member". Users in that role can:
 
 An _Organization Member_ is a user of the Cobalt app who can create an [asset](#asset) as well
 as a [pentest](#pentest). That user can also see the pentesters who are working on their asset.
-If allowed by their {{% ptaas-tier %}}, they can also manage integration with Jira and GitHub (cloud only).
+If allowed by their {{% ptaas-tier %}}, they can also manage integration with Jira and GitHub (Cloud only).
 
 - An _Organization Member_ may also be a [_Pentest Team Member_](#pentest-team-member).
 

--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -169,7 +169,7 @@ In the Cobalt UI, you'll see this user role as "Member". Users in that role can:
 
 An _Organization Member_ is a user of the Cobalt app who can create an [asset](#asset) as well
 as a [pentest](#pentest). That user can also see the pentesters who are working on their asset.
-If allowed by their {{% ptaas-tier %}}, they can also manage integration with Jira and GitHub.
+If allowed by their {{% ptaas-tier %}}, they can also manage integration with Jira and GitHub (cloud only).
 
 - An _Organization Member_ may also be a [_Pentest Team Member_](#pentest-team-member).
 

--- a/content/en/Integrations/_index.md
+++ b/content/en/Integrations/_index.md
@@ -25,7 +25,7 @@ To get started, navigate to the **Integrations** page in the Cobalt app.
 | Integration | Type | Use |
 |:---|:---|:---|
 | <img src="/integrations/Jira.png" width="30"> [Jira](https://cobaltio.zendesk.com/hc/en-us/sections/4407694113044-Integration-Guides) | Native | <li>Push Cobalt findings as issues to Jira Cloud, Server, or Data Center</li><li>Synchronize Cobalt findings with Jira tickets bi-directionally</li>
-| <img src="/integrations/Github.png" width="30"> [GitHub](https://cobaltio.zendesk.com/hc/en-us/articles/360058712591-How-do-I-set-up-GitHub-Integration-) | Native | Push Cobalt findings as issues to GitHub
+| <img src="/integrations/Github.png" width="30"> [GitHub](https://cobaltio.zendesk.com/hc/en-us/articles/360058712591-How-do-I-set-up-GitHub-Integration-) | Native | Push Cobalt findings as issues to GitHub (cloud only)
 | <img src="/integrations/Webhooks.png" width="30"> [Webhooks](/integrations/webhooks/) | Native | Subscribe to real-time notifications for pentest events using API-based webhooks
 | <img src="/integrations/Jupiterone.png" width="30"> [JupiterOne](https://community.askj1.com/kb/articles/994-cobalt-integration-with-jupiterone) | Partner | Analyze pentest data with JupiterOne tools
 | <img src="/integrations/Tugboatlogic.png" width="30"> [Tugboat Logic](https://tugboatlogic.com/integrations/cobalt/) | Partner | Pull Cobalt pentest information into a Tugboat Logic-based InfoSec program

--- a/content/en/Integrations/_index.md
+++ b/content/en/Integrations/_index.md
@@ -25,7 +25,7 @@ To get started, navigate to the **Integrations** page in the Cobalt app.
 | Integration | Type | Use |
 |:---|:---|:---|
 | <img src="/integrations/Jira.png" width="30"> [Jira](https://cobaltio.zendesk.com/hc/en-us/sections/4407694113044-Integration-Guides) | Native | <li>Push Cobalt findings as issues to Jira Cloud, Server, or Data Center</li><li>Synchronize Cobalt findings with Jira tickets bi-directionally</li>
-| <img src="/integrations/Github.png" width="30"> [GitHub](https://cobaltio.zendesk.com/hc/en-us/articles/360058712591-How-do-I-set-up-GitHub-Integration-) | Native | Push Cobalt findings as issues to GitHub (cloud only)
+| <img src="/integrations/Github.png" width="30"> [GitHub](https://cobaltio.zendesk.com/hc/en-us/articles/360058712591-How-do-I-set-up-GitHub-Integration-) | Native | Push Cobalt findings as issues to GitHub (Cloud only)
 | <img src="/integrations/Webhooks.png" width="30"> [Webhooks](/integrations/webhooks/) | Native | Subscribe to real-time notifications for pentest events using API-based webhooks
 | <img src="/integrations/Jupiterone.png" width="30"> [JupiterOne](https://community.askj1.com/kb/articles/994-cobalt-integration-with-jupiterone) | Partner | Analyze pentest data with JupiterOne tools
 | <img src="/integrations/Tugboatlogic.png" width="30"> [Tugboat Logic](https://tugboatlogic.com/integrations/cobalt/) | Partner | Pull Cobalt pentest information into a Tugboat Logic-based InfoSec program


### PR DESCRIPTION
## Changelog

Based on internal discussion, noted limit in our integration support to GitHub Cloud

### Added
n/a

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| [Glossary] | [[Link](https://deploy-preview-217--cobalt-docs.netlify.app/getting-started/glossary/#organization-member)] | [Select "Learn More" to reveal detail] |
| [Integrations] | [[Link](https://deploy-preview-217--cobalt-docs.netlify.app/integrations/)] | [See GitHub in the table] |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{ % asset-categories % }}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.
