### PR TITLE
[DOCS-317] Update 404 Links

### DIFF
--- a/content/en/Getting started/Pentest objectives/_index.md
+++ b/content/en/Getting started/Pentest objectives/_index.md
@@ -24,7 +24,7 @@ On this page of the UI, you can:
 - Define a [Pentest Methodology](./methodologies), with detailed objectives. You can
   read about the objectives associated with each [asset](../glossary#asset) type.
 - Include [Test Credentials](./test-credentials).
-- Add special [Instructions](./special-instructions).
+- Add special [Instructions](/getting-started/pentest-objectives/special-instructions/).
 - Define the [Technology Stack](./stack).
 
 If you're not sure what to include in the UI, follow the links associated with each

--- a/content/en/Getting started/Pentest objectives/pentest-target.md
+++ b/content/en/Getting started/Pentest objectives/pentest-target.md
@@ -20,7 +20,7 @@ their location on the internet.
 | Mobile           | URL where anyone can download a mobile app, such as on Google Play or the Apple App Store.                                               |
 | API              | Base URL of the API. You can define the endpoints / queries in the Instructions text box. |
 | External Network | IP addresses or the IP network address.                                                   |
-| Internal Network | IP network address. External IP address for the [Jump Box](../../glossary/#jump-box).                             |
+| Internal Network | IP network address. External IP address for the [Jump Box](/getting-started/glossary/#jump-box).                             |
 | Cloud Config     | IP address(es) and FQDNs of your cloud components.                                        |
 
 After you've defined the target, proceed with the [Pentest Methodology](../methodologies).

--- a/content/en/Getting started/Pentest objectives/test-credentials.md
+++ b/content/en/Getting started/Pentest objectives/test-credentials.md
@@ -18,7 +18,7 @@ When you see that title, select from the following options:
   - We'll share email addresses once your pentest is in the [Planned](../../../penteststates/) state. 
 - `Pentesters can create their own credentials / No authentication required`
 
-Explain the process in the special [Instructions](../special-instructions), based on the
+Explain the process in the special [Instructions](/getting-started/pentest-objectives/special-instructions/), based on the
 following use cases:
 - If our pentesters can create their own accounts on your system
 - If our pentesters can test your system without credentials
@@ -31,11 +31,11 @@ If you've set up dedicated accounts:
   - Share documentation on how your pentesters can set their own passwords.
   - If necessary, share username/password (or other credential) information using the _secure_ channel of your choice.
 - Describe the user role along with associated permissions and/or privileges.
-- Include other authentication requirements such as [multi-factor authentication (MFA)](../../glossary/#multi-factor-authentication).
+- Include other authentication requirements such as [multi-factor authentication (MFA)](/getting-started/glossary/#multi-factor-authentication).
 - Once the pentest (and any retests) are complete, delete the dedicated accounts.
 
 Depending on the methodology, we may also perform
-[black-box](../../glossary/#black-box-testing) and 
-[gray-box](../../glossary/#gray-box-testing) tests.
+[black-box](/getting-started/glossary/#black-box-testing) and 
+[gray-box](/getting-started/glossary/#gray-box-testing) tests.
 
-Now proceed to the next step, special [Instructions](../special-instructions).
+Now proceed to the next step, special [Instructions](/getting-started/pentest-objectives/special-instructions/).

--- a/content/en/Getting started/Sign In/_index.md
+++ b/content/en/Getting started/Sign In/_index.md
@@ -47,13 +47,13 @@ Now you can:
 
 ## SAML SSO
 
-We support single sign-on (SSO) based on [Security Assertion Markup Language](../glossary/#security-assertion-markup-language) 2.0 (SAML 2.0). Once enabled, you can sign in to the Cobalt app through a third-party identity provider selected by your company.
+We support single sign-on (SSO) based on [Security Assertion Markup Language](/getting-started/glossary/#security-assertion-markup-language) 2.0 (SAML 2.0). Once enabled, you can sign in to the Cobalt app through a third-party identity provider selected by your company.
 
 {{% alert title="Note" color="note" %}}
 SAML-based single sign-on (SSO) is available to all <a href="https://www.cobalt.io/pentest-pricing" target="_blank">PtaaS tiers</a>.
 {{% /alert %}}
 
-Once your [_Organization Owner_](../glossary/#organization-owner) has configured SAML SSO, you need to sign in to the Cobalt app through the identity provider instead of the Cobalt {{% sign-in %}} page. Procedures differ for each identity provider.
+Once your [_Organization Owner_](/getting-started/glossary/#organization-owner) has configured SAML SSO, you need to sign in to the Cobalt app through the identity provider instead of the Cobalt {{% sign-in %}} page. Procedures differ for each identity provider.
 
 Learn more about [configuring SAML SSO](https://cobaltio.zendesk.com/hc/en-us/sections/360012774052--SAML-SSO-).
 

--- a/content/en/Getting started/Sign In/account-recovery.md
+++ b/content/en/Getting started/Sign In/account-recovery.md
@@ -12,11 +12,11 @@ Refer to this page if you lose access to your authenticator app or forget your p
 
 ## Lost Access to Your Authenticator
 
-Users in the following roles can ask an [_Organization Owner_](../../glossary/#organization-owner) to turn off [two-factor authentication](../#two-factor-authentication) (2FA) for their account:
+Users in the following roles can ask an [_Organization Owner_](/getting-started/glossary/#organization-owner) to turn off [two-factor authentication](../#two-factor-authentication) (2FA) for their account:
 
-- [_Organization Owner_](../../glossary/#organization-owner)
-- [_Organization Member_](../../glossary/#organization-member)
-- [_Pentest Team Member_](../../glossary/#pentest-team-member)
+- [_Organization Owner_](/getting-started/glossary/#organization-owner)
+- [_Organization Member_](/getting-started/glossary/#organization-member)
+- [_Pentest Team Member_](/getting-started/glossary/#pentest-team-member)
 
 Follow these steps:
 
@@ -40,7 +40,7 @@ Once you've set up a new authenticator, you can turn on 2FA again.
 
 ### Turn Off 2FA for a User
 
-As an [_Organization Owner_](../../glossary/#organization-owner), you can turn off two-factor authentication for a user following their request.
+As an [_Organization Owner_](/getting-started/glossary/#organization-owner), you can turn off two-factor authentication for a user following their request.
 
 1. Once you get an email notification requesting you to turn off 2FA, select **Recover Account** in the email.
 

--- a/content/en/Getting started/_index.md
+++ b/content/en/Getting started/_index.md
@@ -49,9 +49,9 @@ Our journey takes you through the steps required to create a pentest:
 1. Set [requirements](./pentest-objectives) for your pentest.
    - By default, our pentesters use standards defined by the
      [Open Web Application Security
-     Project (OWASP)](./glossary#open-web-application-security-project-owasp) and in
+     Project (OWASP)](/getting-started/glossary/#open-web-application-security-project-owasp) and in
      the [Open Source Security Testing Methodology
-     Manual](./glossary/#open-source-security-testing-methodology-manual-osstmm).
+     Manual](/getting-started/glossary/#open-source-security-testing-methodology-manual-osstmm).
    - Add and modify the objectives of your choice.
    - To help our penetration testers, include more information about your asset,
      such as architecture and coding language. You'll see more details about

--- a/content/en/Getting started/checklist.md
+++ b/content/en/Getting started/checklist.md
@@ -61,7 +61,7 @@ You can download a pentest [report](/platform-deep-dive/pentests/reports/) to vi
 
 If your organization manages pentests for third parties, you can add your company logo to all reports. In co-branded reports, your company logo appears next to the Cobalt logo.
 
-An [_Organization Owner_](../glossary/#organization-owner) of a partner company can enable co-branded reports.
+An [_Organization Owner_](/getting-started/glossary/#organization-owner) of a partner company can enable co-branded reports.
 
 {{%expand "Learn more." %}}
 

--- a/content/en/Getting started/details.md
+++ b/content/en/Getting started/details.md
@@ -83,7 +83,7 @@ see our page on [Cloud Methodologies](../pentest-objectives/methodologies/cloud)
 ### Additional Guidelines
 
 You may have already addressed these questions when setting up 
-[Special Instructions](../pentest-objectives/special-instructions) when defining pentest requirements.
+[Special Instructions](/getting-started/pentest-objectives/special-instructions/) when defining pentest requirements.
 
 You're welcome to add more information here.
 
@@ -101,7 +101,7 @@ Our pentesters take extra care to protect that information.
 
 Some apps support the use of credit cards for purchases. If you provide
 test credit card numbers, you can share that information in the 
-[instructions](../pentest-objectives/special-instructions) or in the "Kickoff call."
+[instructions](/getting-started/pentest-objectives/special-instructions/) or in the "Kickoff call."
 
 {{% alert title="Note" color="note" %}}
 All Cobalt pentesters have signed a Non-Disclosure Agreement (NDA).

--- a/content/en/Getting started/planning.md
+++ b/content/en/Getting started/planning.md
@@ -32,7 +32,7 @@ The pentest scope determines the number of credits required for a pentest. The b
 
 To set the pentest scope, identify the complexity of your asset. Under **Scoping**, specify the number of characteristics associated with the asset that need to be tested. To get exact numbers, consult with the asset owner inside your organization.
 
-The characteristics differ for each [asset type](../assets/asset-type/):
+The characteristics differ for each [asset type](/getting-started/assets/asset-type/):
 
 - [Web](#web)
 - [Mobile](#mobile)

--- a/content/en/Getting started/what-to-expect.md
+++ b/content/en/Getting started/what-to-expect.md
@@ -67,5 +67,5 @@ results. Here's what you can expect:
 
    <!-- Timing confirmed with Grahame -->
 
-Our [Pentest States](../../../penteststates/) page includes more information about each pentest
+Our [Pentest States](/penteststates/) page includes more information about each pentest
 state, including _Draft_, _In Review_, _Planned_, _Remediation_, and _Closed_.

--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/_index.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/_index.md
@@ -29,7 +29,7 @@ asset.
 - [External Network](./external-network)
 - [Cloud](./cloud)
 
-In most cases, the Methodology is fixed, based on the [Asset Type](../../assets/asset-type)
+In most cases, the Methodology is fixed, based on the [Asset Type](/getting-started/assets/asset-type/)
 you defined earlier. However, if you selected a combined asset type, such as Web + API, you
 can limit the test to either of the individual methodologies:
 
@@ -38,10 +38,10 @@ can limit the test to either of the individual methodologies:
 Review the methodology for your asset, from the links shown earlier. Each methodology
 includes default requirements based on standards such as:
 
-- [OWASP](../../glossary/#open-web-application-security-project-owasp)
-- [OSSTMM](../../glossary/#open-source-security-testing-methodology-manual-osstmm)
+- [OWASP](/getting-started/glossary/#open-web-application-security-project-owasp)
+- [OSSTMM](/getting-started/glossary/#open-source-security-testing-methodology-manual-osstmm)
 
 You're welcome to include additional requirements.
 
-Next, you'll want to set up and share [Test Credentials](../test-credentials) for your
+Next, you'll want to set up and share [Test Credentials](/getting-started/pentest-objectives/test-credentials/) for your
 pentesters.

--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/cloud.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/cloud.md
@@ -37,7 +37,7 @@ follows an industry standard methodology primarily based on:
 
 - Best practices established by your cloud provider
 - OWASP standards for [Cloud Providers](https://owasp.org/www-pdf-archive/Cloud-Top10-Security-Risks.pdf) (PDF)
-  and [Application Security Verification Standard (ASVS)](../../../glossary#application-security-verification-standard-asvs).
+  and [Application Security Verification Standard (ASVS)](/getting-started/glossary#application-security-verification-standard-asvs).
 
 The Cobalt team of pentesters do not need access to the underlying web application
 source code, unless you specify it as a requirement.
@@ -64,7 +64,7 @@ We've included links to procedures that we know of in the section for each provi
 ### Source IP Addresses
 
 Cloud providers may need to include IP addresses associated with pentest traffic in
-their [allowlist](../../../glossary#allowlist). We'll share these addresses when you
+their [allowlist](/getting-started/glossary#allowlist). We'll share these addresses when you
 create an actual pentest.
 
 ### Testing Parameters

--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/internal-network.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/internal-network.md
@@ -13,7 +13,7 @@ Overview of test methodologies for Internal networks.
 {{% /pageinfo %}}
 
 We use the penetration testing methodologies listed on the page, based in large part on the
-[OSSTMM](../../../glossary#open-source-security-testing-methodology-manual-osstmm).
+[OSSTMM](/getting-started/glossary#open-source-security-testing-methodology-manual-osstmm).
 
 ## Special Pentester Needs
 

--- a/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/internal-network.md
+++ b/content/en/Platform Deep Dive/Pentests/Pentest Process/Methodologies/internal-network.md
@@ -21,7 +21,7 @@ Our pentests of internal networks are all performed remotely. To support this ac
 pentesters need:
 
 - Access to your internal network through a stable VPN.
-- A lightweight Linux server inside the network, used as a [jump box](../../../glossary#jump-box).
+- A lightweight Linux server inside the network, used as a [jump box](/getting-started/glossary#jump-box).
   - If you use AWS for your internal network, you can use
     [this link](https://aws.amazon.com/marketplace/pp/prodview-fznsw3f7mq7to) to set up a virtual machine.
   - You can also download a [Kali VM Image](https://www.kali.org/get-kali).

--- a/layouts/shortcodes/additional-requirements.html
+++ b/layouts/shortcodes/additional-requirements.html
@@ -3,4 +3,4 @@
 OWASP, ASVS, or OSSTMM, let us know. Include a link or other documentation. If it&rsquo;s a
 &ldquo;well-known&rdquo; security practice, our pentesters probably already know them!</p>
 <p>If you have special instructions for a pentest,
-add them later, under <a href="../../special-instructions">Special Instructions</a>.</p>
+add them later, under <a href="/getting-started/pentest-objectives/special-instructions/">Special Instructions</a>.</p>


### PR DESCRIPTION
## Changelog

### Updated

Several links: changed the format from relative to absolute.

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.
