### PR TITLE
[NO_TICKET] Add Alt Text to Images

### DIFF
--- a/content/en/Integrations/_index.md
+++ b/content/en/Integrations/_index.md
@@ -22,15 +22,15 @@ To get started, navigate to the **Integrations** page in the Cobalt app.
 <!-- Links to Zendesk are temporary. We'll change them once the content is moved to Product Docs. -->
 | Integration | Type | Use |
 |:---|:---|:---|
-| <img src="/integrations/Jira.png" width="30"> [Jira](https://cobaltio.zendesk.com/hc/en-us/sections/4407694113044-Integration-Guides) | Native | <li>Push Cobalt findings as issues to Jira Cloud, Server, or Data Center</li><li>Synchronize Cobalt findings with Jira tickets bi-directionally</li>
-| <img src="/integrations/Github.png" width="30"> [GitHub](https://cobaltio.zendesk.com/hc/en-us/articles/360058712591-How-do-I-set-up-GitHub-Integration-) | Native | Push Cobalt findings as issues to GitHub (Cloud only)
-| <img src="/integrations/Webhooks.png" width="30"> [Webhooks](/integrations/webhooks/) | Native | Subscribe to real-time notifications for pentest events using API-based webhooks
-| <img src="/integrations/Jupiterone.png" width="30"> [JupiterOne](https://community.askj1.com/kb/articles/994-cobalt-integration-with-jupiterone) | Partner | Analyze pentest data with JupiterOne tools
-| <img src="/integrations/Tugboatlogic.png" width="30"> [Tugboat Logic](https://tugboatlogic.com/integrations/cobalt/) | Partner | Pull Cobalt pentest information into a Tugboat Logic-based InfoSec program
-| <img src="/integrations/Defectdojo.png" width="30"> [DefectDojo](https://defectdojo.github.io/django-DefectDojo/integrations/parsers/#cobaltio-api-import) | Partner | Import your Cobalt pentest findings into DefectoDojo with Cobalt API
-| <img src="/integrations/Kennasecurity.png" width="30"> [Kenna Security](https://github.com/KennaSecurity/toolkit/tree/main/tasks/connectors/cobaltio#readme) | Partner | Import Cobalt pentest findings
-| <img src="/integrations/PlexTrac.png" width="30"> [PlexTrac](https://docs.plextrac.com/plextrac-documentation/product-documentation/account-management/account-admin/tools-and-integrations/integrations/cobalt) | Partner | Import Cobalt findings into a PlexTrac report
-| <img src="/integrations/anecdotes.png" width="30"> [anecdotes](https://intercom.help/anecdotes/en/articles/6508884-cobalt-getting-started-user-guide) | Partner | Integrate Cobalt findings into the anecdotes.ai compliance operating system
+| <img src="/integrations/Jira.png" alt="Jira icon" title="Jira icon" width="30"> [Jira](https://cobaltio.zendesk.com/hc/en-us/sections/4407694113044-Integration-Guides) | Native | <li>Push Cobalt findings as issues to Jira Cloud, Server, or Data Center</li><li>Synchronize Cobalt findings with Jira tickets bi-directionally</li>
+| <img src="/integrations/Github.png" alt="GitHub icon" title="GitHub icon" width="30"> [GitHub](https://cobaltio.zendesk.com/hc/en-us/articles/360058712591-How-do-I-set-up-GitHub-Integration-) | Native | Push Cobalt findings as issues to GitHub (Cloud only)
+| <img src="/integrations/Webhooks.png" alt="Webhooks icon" title="Webhooks icon" width="30"> [Webhooks](/integrations/webhooks/) | Native | Subscribe to real-time notifications for pentest events using API-based webhooks
+| <img src="/integrations/Jupiterone.png" alt="JupiterOne icon" title="JupiterOne icon" width="30"> [JupiterOne](https://community.askj1.com/kb/articles/994-cobalt-integration-with-jupiterone) | Partner | Analyze pentest data with JupiterOne tools
+| <img src="/integrations/Tugboatlogic.png" alt="Tugboat Logic icon" title="Tugboat Logic icon" width="30"> [Tugboat Logic](https://tugboatlogic.com/integrations/cobalt/) | Partner | Pull Cobalt pentest information into a Tugboat Logic-based InfoSec program
+| <img src="/integrations/Defectdojo.png" alt="DefectDojo icon" title="DefectDojo icon" width="30"> [DefectDojo](https://defectdojo.github.io/django-DefectDojo/integrations/parsers/#cobaltio-api-import) | Partner | Import your Cobalt pentest findings into DefectoDojo with Cobalt API
+| <img src="/integrations/Kennasecurity.png" alt="Kenna Security icon" title="Kenna Security icon" width="30"> [Kenna Security](https://github.com/KennaSecurity/toolkit/tree/main/tasks/connectors/cobaltio#readme) | Partner | Import Cobalt pentest findings
+| <img src="/integrations/PlexTrac.png" alt="PlexTrac icon" title="PlexTrac icon" width="30"> [PlexTrac](https://docs.plextrac.com/plextrac-documentation/product-documentation/account-management/account-admin/tools-and-integrations/integrations/cobalt) | Partner | Import Cobalt findings into a PlexTrac report
+| <img src="/integrations/anecdotes.png" alt="anecdotes icon" title="anecdotes icon" width="30"> [anecdotes](https://intercom.help/anecdotes/en/articles/6508884-cobalt-getting-started-user-guide) | Partner | Integrate Cobalt findings into the anecdotes.ai compliance operating system
 
 ## Build Your Own Integration
 


### PR DESCRIPTION
## Changelog

### Updates

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Cobalt Integrations | https://deploy-preview-223--cobalt-docs.netlify.app/integrations/ | `alt` and `title` attributes for images |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.
