### PR TITLE
[DOCS-321] Cobalt Capitalization Rules (Vale)

### DIFF
--- a/content/en/Getting started/checklist.md
+++ b/content/en/Getting started/checklist.md
@@ -80,7 +80,7 @@ An [_Organization Owner_](/getting-started/glossary/#organization-owner) of a pa
 <li>Upload the logo image, and select <b>Apply</b>.</li></ul></li>
 
 <li>To verify that co-branding is enabled:
-<ul><li>Go to the <b>Pentests</b> tab, and select a pentest in the <i>Remediation</i> or <i>Closed</i> state.</li>
+<ul><li>Go to the <b>Pentests</b> tab, and select a pentest in the Remediation or Closed state.</li>
 <li>On the <b>Report</b> tab, download a report, and verify that it has your company logo.</li></ul></li>
 </ol>
 

--- a/content/en/Getting started/what-to-expect.md
+++ b/content/en/Getting started/what-to-expect.md
@@ -14,14 +14,14 @@ Now that you've done all the work needed to set up a pentest, you might be anxio
 results. Here's what you can expect:
 
 1. Once you've finished setting up a pentest, select **Pentests** in the left-hand
-   pane. You should see your pentest listed, with an _In Review_ label.
+   pane. You should see your pentest listed, with an In Review label.
 1. We'll select the best available testers before the start of the pentest. The time we need
    depends on your {{% ptaas-tier %}} and any special requirements you have.
 1. Once we start the pentest, you’ll start getting updates from pentesters:
    - On the **Pentester Updates** tab of the pentest page
    - In a Slack channel dedicated for your pentest where you can communicate with pentesters. You should see a link to the Slack channel on the pentest page next to the pentest state.
       - Add the colleagues of your choice to the Slack channel. Choose colleagues who can benefit from direct communication with our pentesters.
-      - As soon as we’ve moved your pentest from _In Review_ to _Planned_, you’ll see your pentesters in the Slack channel.
+      - As soon as we’ve moved your pentest from In Review to Planned, you’ll see your pentesters in the Slack channel.
 1. You may get questions from your pentesters. You can also elaborate
    on your requirements for the pentest.
    - You'll get in-app and email notifications for each update from pentesters.
@@ -37,7 +37,7 @@ results. Here's what you can expect:
    start remediating your code before you see a pentest report.
    {{% /alert %}}
 
-1. Once the pentest is complete, we move your pentest from _Planned_ to _Remediation_.
+1. Once the pentest is complete, we move your pentest from Planned to Remediation.
 1. You can start assessing all discovered vulnerabilities. In the Cobalt app, navigate
    to **Pentests**. Select your pentest, and navigate to the **Findings** tab.
    - Find the **State** list. Depending on your assessment, you can
@@ -68,4 +68,4 @@ results. Here's what you can expect:
    <!-- Timing confirmed with Grahame -->
 
 Our [Pentest States](/penteststates/) page includes more information about each pentest
-state, including _Draft_, _In Review_, _Planned_, _Remediation_, and _Closed_.
+state, including Draft, In Review, Planned, Remediation, and Closed.

--- a/content/en/PentestStates/_index.md
+++ b/content/en/PentestStates/_index.md
@@ -26,9 +26,8 @@ through our user interface. Here's the meaning of each label:
 | Cancelled   | If you no longer need a pentest, you're always welcome to cancel it. We'll keep the pentest in our records in case you change your mind.                                                                                                  |
 
 {{% alert title="Note" color="note" %}}
-Pentests remain in _Remediation_ until you've addressed all findings. You can address each finding by either:
+Pentests remain in Remediation until you've addressed all findings. You can address each finding by either:
 
 - Remediating the finding.
 - Accepting the finding, and any associated security risk.
 {{% /alert %}}
-

--- a/styles/cobalt/Capitalization.yml
+++ b/styles/cobalt/Capitalization.yml
@@ -1,0 +1,24 @@
+---
+# Checks the capitalization of terms specific to Cobalt.
+extends: substitution
+message: 'Use "%s" instead of "%s".'
+level: warning
+ignorecase: false
+swap:
+  agile pentest: Agile Pentest
+  Agile pentest: Agile Pentest
+  agile Pentest: Agile Pentest
+  comprehensive pentest: Comprehensive Pentest
+  Comprehensive pentest: Comprehensive Pentest
+  comprehensive Pentest: Comprehensive Pentest
+  Cobalt App: Cobalt app
+  cobalt app: Cobalt app
+  cobalt App: Cobalt app
+  draft state: Draft state
+  in review state: In Review state
+  planned state: Planned state
+  live state: Live state
+  paused state: Paused state
+  remediation state: Remediation state
+  closed state: Closed state
+  cancelled state: Cancelled state

--- a/styles/cobalt/Substitutions.yml
+++ b/styles/cobalt/Substitutions.yml
@@ -11,9 +11,6 @@ link: https://about.gitlab.com/handbook/communication/#top-misused-terms
 level: error
 ignorecase: true
 swap:
-  Agile pentest: Agile Pentest
-  Comprehensive pentest: Comprehensive Pentest
-  Cobalt App: Cobalt app
   codequality: code quality
   Customer [Pp]ortal: Customers Portal
   frontmatter: front matter


### PR DESCRIPTION
## Changelog

### Added

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Capitalization.yml | https://github.com/cobalthq/cobalt-product-public-docs/pull/224/files#diff-df9caf1ee0154ef9669eaf5ef47f56354b7b463a81b24fbed4a19eb85fc63514 | Vale rule to check the capitalization of terms specific to Cobalt |

### Updated

Formatting of pentest states in several articles.

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
