### PR TITLE
[NO-TICKET] Labels for Tiers

### DIFF
--- a/content/en/Platform Deep Dive/Pentests/Reports/customize-report.md
+++ b/content/en/Platform Deep Dive/Pentests/Reports/customize-report.md
@@ -10,6 +10,12 @@ description: >
 This feature may be limited to subscribers with a specific {{% ptaas-tier %}}.
 {{% /pageinfo %}}
 
+<div>
+<span style="border-radius:10px;-webkit-border-radius:10px;-moz-border-radius:10px;background-color:#8E3EDB;padding:10px;text-align:center;opacity:75%;"><span style="color: #FFFFFF;font-weight:bold;">Premium</span></span> <span style="border-radius:10px;-webkit-border-radius:10px;-moz-border-radius:10px;background-color:#0DB285;padding:10px;text-align:center;opacity:75%;"><span style="color: #FFFFFF;font-weight:bold;">Enterprise</span>
+</span>
+</div>
+<br>
+
 You can customize the following report types for [Comprehensive Pentests](/getting-started/glossary/#comprehensive-pentest):
 
 - Customer Letter


### PR DESCRIPTION
## Changelog

### Added

Test PR. Added labels showing PtaaS tiers. @mjang-cobalt 

<img width="794" alt="Screenshot 2022-11-23 at 14 30 49" src="https://user-images.githubusercontent.com/106706890/203559113-180d7355-6d3e-49aa-bf2f-0ac9e97be8ae.png">

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
