### PR TITLE
[DOCS-255] Anonymize or delete your account data

### DIFF
--- a/content/en/Platform Deep Dive/Cobalt Account/_index.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/_index.md
@@ -11,3 +11,22 @@ Once you've confirmed your email address and created a password, your Cobalt acc
 {{% /pageinfo %}}
 
 Tune your account settings, and learn how to [recover your account](/platform-deep-dive/cobalt-account/account-recovery/) if you can't sign in.
+
+## Protect Your Personal Data
+
+You may want to **anonymize or delete your account data** in compliance with [General Data Protection Regulation (GDPR)](https://gdpr.eu/).
+
+{{%expand "Learn more about GDPR policies." %}}
+
+- [Rights of the data subject](https://gdpr.eu/tag/chapter-3/)
+- [Right to erasure ('right to be forgotten')](https://gdpr.eu/article-17-right-to-be-forgotten/)
+- [Right to restriction of processing](https://gdpr.eu/article-18-right-to-restriction-of-processing/)
+{{% /expand%}}
+<br>
+
+- When a user requests to **anonymize** their account data, we obfuscate user details using a one-way function that prevents identifying the user in any way.
+- When a user requests to **delete** their account data, we erase all user’s personal data from our system.
+
+To anonymize or delete your Cobalt account, send a request to privacy@cobalt.io from the email address that you used to set up your account. Include your account details in the email. We'll process your request within 30 days.
+
+Anonymizing or deleting your account is **irreversible**. If you no longer want to belong to your organization or collaborate on pentests, ask your [Organization Owner](/getting-started/glossary/#organization-owner) to remove you from the organization or specific pentest. In this case, you don't need to delete your account.


### PR DESCRIPTION
## Changelog

@mjang-cobalt I decided to name this section "Protect Your Account Data" instead of "Request to Anonymize or Delete Your Account Data" because the section is located on the main Cobalt Account page. It may look discouraging if users see these instructions once they navigate to this section. We may change the location, suggestions are welcome.

### Added

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Cobalt Account > Protect Your Personal Data | https://deploy-preview-239--cobalt-docs.netlify.app/platform-deep-dive/cobalt-account/ | |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
