### PR TITLE
[DOCS-253, -258] Get in Touch

### DIFF
--- a/content/en/Getting started/_index.md
+++ b/content/en/Getting started/_index.md
@@ -70,3 +70,13 @@ you can [expect](./what-to-expect).
 
 Assuming you've received an email invitation, take the next step.
 [Sign in to Cobalt](./sign-in).
+
+## Get in Touch
+
+If you need help, contact us in one of the following ways:
+
+- If you have a named Customer Success Manager, get in touch with them.
+- Send an email to support@cobalt.io.
+- [Submit a ticket](https://cobaltio.zendesk.com/hc/en-us/requests/new) on the support portal.
+
+If you found a security issue on the Cobalt platform, please report it to security@cobalt.io. Learn more about our [security practices](https://cobalt.io/security/practices).

--- a/content/en/Getting started/_index.md
+++ b/content/en/Getting started/_index.md
@@ -79,4 +79,4 @@ If you need help, contact us in one of the following ways:
 - Send an email to support@cobalt.io.
 - [Submit a ticket](https://cobaltio.zendesk.com/hc/en-us/requests/new) on the support portal.
 
-If you found a security issue on the Cobalt platform, please report it to security@cobalt.io. Learn more about our [security practices](https://cobalt.io/security/practices).
+If you find a security issue on the Cobalt platform, please report it to security@cobalt.io. Learn more about our [security practices](https://cobalt.io/security/practices).


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Getting Started > Get in Touch | https://deploy-preview-246--cobalt-docs.netlify.app/getting-started/#get-in-touch | IMO, this content should be on the home page, but it doesn't align with the current content. I suggested a new outline of the home page in a private Slack message. We can move this section later once we change the portal theme. |

I decided to omit the instruction describing how to send a request through the bot on the support portal because:
- The user needs to take more steps to achieve the same result -- comparing to sending an email.
- We're moving content off of Zendesk, so it will make less sense to use the bot to search for answers.
- 4 ways to contact support is too much.

<img width="344" alt="Screenshot 2022-12-01 at 11 31 51" src="https://user-images.githubusercontent.com/106706890/205030196-894477ac-e412-47eb-bf9e-bad4a2a7bc7e.png">

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
