### PR TITLE
[DOCS-278] Invite Multiple Users

### DIFF
--- a/content/en/Platform Deep Dive/Collaboration/Organization/manage-users.md
+++ b/content/en/Platform Deep Dive/Collaboration/Organization/manage-users.md
@@ -21,18 +21,21 @@ As an [Organization Owner](/getting-started/glossary/#organization-owner), you c
 
 ### Invite Users
 
-To invite a user to your organization:
+To invite users to your organization:
 
 1. In the Cobalt app, select your organization.
-1. Navigate to the **People** page.
-1. In the input field, enter the email address of the user that you want to invite.
-1. Select the user role from the list: Member or Owner. Select **Add Member/Owner**.
+1. Navigate to the **People** page, and select **Invite People**.
+1. In the overlay that appears, enter the email addresses of users that you want to invite.
+   - Use commas to separate multiple email addresses.
+1. For each user, select a role: Member or Owner.
     - Both Members and Owners have access to all [assets](/platform-deep-dive/assets/) and [pentests](/platform-deep-dive/pentests/) of an organization.
-1. In the overlay that appears, select whether you want to invite the user to:
-    - The organization and all pentests
-    - Only to the organization
+1. Select **Invite** to confirm.
 
-The user receives an email invitation to join your organization.
+Users receive an email invitation to join your organization. They also become collaborators on all pentests of the organization as [Pentest Team Members](/getting-started/glossary/#pentest-team-member).
+
+If an email address is invalid or a user has already joined, you see an error message.
+
+![Invite multiple users to your organization](/deepdive/InviteUsers.png "Overlay for inviting multiple users")
 
 ### Change a User’s Role
 

--- a/content/en/Platform Deep Dive/Collaboration/Organization/manage-users.md
+++ b/content/en/Platform Deep Dive/Collaboration/Organization/manage-users.md
@@ -27,7 +27,7 @@ To invite users to your organization:
 1. Navigate to the **People** page, and select **Invite People**.
 1. In the overlay that appears, enter the email addresses of users that you want to invite.
    - Use commas to separate multiple email addresses.
-1. For each user, select a role: Member or Owner.
+1. For each user, select a [role](/platform-deep-dive/collaboration/organization/user-roles/): Member or Owner.
     - Both Members and Owners have access to all [assets](/platform-deep-dive/assets/) and [pentests](/platform-deep-dive/pentests/) of an organization.
 1. Select **Invite** to confirm.
 

--- a/content/en/Platform Deep Dive/Collaboration/Organization/manage-users.md
+++ b/content/en/Platform Deep Dive/Collaboration/Organization/manage-users.md
@@ -25,7 +25,7 @@ To invite users to your organization:
 
 1. In the Cobalt app, select your organization.
 1. Navigate to the **People** page, and select **Invite People**.
-1. In the overlay that appears, enter the email addresses of users that you want to invite. Type the email, and press Enter to confirm.
+1. In the overlay that appears, specify the email addresses of users that you want to invite. Enter the emails, and press Enter to confirm.
    - Use commas to separate multiple email addresses.
 1. For each user, select a [role](/platform-deep-dive/collaboration/organization/user-roles/): Member or Owner.
     - Both Members and Owners have access to all [assets](/platform-deep-dive/assets/) and [pentests](/platform-deep-dive/pentests/) of an organization.

--- a/content/en/Platform Deep Dive/Collaboration/Organization/manage-users.md
+++ b/content/en/Platform Deep Dive/Collaboration/Organization/manage-users.md
@@ -25,7 +25,7 @@ To invite users to your organization:
 
 1. In the Cobalt app, select your organization.
 1. Navigate to the **People** page, and select **Invite People**.
-1. In the overlay that appears, enter the email addresses of users that you want to invite.
+1. In the overlay that appears, enter the email addresses of users that you want to invite. Type the email, and press Enter to confirm.
    - Use commas to separate multiple email addresses.
 1. For each user, select a [role](/platform-deep-dive/collaboration/organization/user-roles/): Member or Owner.
     - Both Members and Owners have access to all [assets](/platform-deep-dive/assets/) and [pentests](/platform-deep-dive/pentests/) of an organization.
@@ -33,7 +33,7 @@ To invite users to your organization:
 
 Users receive an email invitation to join your organization. They also become collaborators on all pentests of the organization as [Pentest Team Members](/getting-started/glossary/#pentest-team-member).
 
-If an email address is invalid or a user has already joined, you see an error message.
+<!--If an email address is invalid or a user has already joined, you see an error message.-->
 
 ![Invite multiple users to your organization](/deepdive/InviteUsers.png "Overlay for inviting multiple users")
 


### PR DESCRIPTION
## Changelog

@mjang-cobalt These changes were earlier updated in https://github.com/cobalthq/cobalt-product-public-docs/pull/220.

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Manage Users > Invite Users | https://deploy-preview-253--cobalt-docs.netlify.app/platform-deep-dive/collaboration/organization/manage-users/#invite-users | New flow for inviting users |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
