### PR TITLE
Update account-recovery.md

### DIFF
--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -11,6 +11,10 @@ description: >
 If you have problems signing in, refer to the instructions on this page. To get more help, reach out to {{% csm-support %}}.
 {{% /pageinfo %}}
 
+{{< alert title="Note" color="primary" >}}
+Before proceeding, ask your Organization Owner if SAML-based single sign-on (SSO) is enabled for your organization. If yes, sign in from the identity provider system, not the Cobalt {{% sign-in %}} page. For more troubleshooting tips, see [Can’t Sign In Using SAML SSO](#cant-sign-in-using-saml-sso), below.
+{{< /alert >}}
+
 Follow these instructions if you can't sign in to Cobalt because:
 
 - You have [problems with two-factor authentication (2FA)](#problems-with-two-factor-authentication):


### PR DESCRIPTION
## Changelog

@molfinn Based on our discussion in Slack, I recommend to add a note to the top of the Account Recovery page to make it visible.

@mjang-cobalt Context: users may not know that SAML SSO is enabled for their organization. They won't scroll down to the SAML SSO troubleshooting tips because of this. We need to make this info more visible.

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Account Recovery | Link | Note about SSO |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
