### PR TITLE
[DOCS-322] We Don't Recognize Your Device

### DIFF
--- a/content/en/Getting started/Sign In/_index.md
+++ b/content/en/Getting started/Sign In/_index.md
@@ -46,7 +46,7 @@ Now you can:
    - Through [SAML SSO](#saml-sso), if configured
 
 {{< alert title="Tip" color="primary" >}}
-If you have problems signing in, see [Account Recovery](/platform-deep-dive/cobalt-account/account-recovery/).
+If you have problems signing in, see [Troubleshoot Issues with Signing In](/platform-deep-dive/cobalt-account/account-recovery/).
 {{< /alert >}}
 
 ## SAML SSO

--- a/content/en/Getting started/Sign In/_index.md
+++ b/content/en/Getting started/Sign In/_index.md
@@ -72,6 +72,14 @@ We support two-factor authentication (2FA). If you're using [SAML SSO](#saml-sso
 {{% 2fa-see-troubleshooting %}}
 {{< /alert >}}
 
+## Device Verification
+
+{{% device-verification-intro %}}
+
+{{< alert title="Tip" color="primary" >}}
+If you see the **Verify It’s You** message upon signing in, follow the steps described in [We Can’t Recognize Your Device](/platform-deep-dive/cobalt-account/account-recovery/#we-cant-recognize-your-device).
+{{< /alert >}}
+
 ## Next Step
 
 You can start [defining your assets](/getting-started/assets/). Select **New Asset** to proceed.

--- a/content/en/Getting started/Sign In/_index.md
+++ b/content/en/Getting started/Sign In/_index.md
@@ -26,18 +26,8 @@ Open the email. It should include a link to Get Started:
 Now you can:
 
 1. Select the link in your email.
-
-1. From the webpage that appears, create a password. Follow the complexity
-   requirements on the screen. We require passwords with at least:
-   - Eight (8) characters
-   - One (1) uppercase letter
-   - One (1) lowercase letter
-   - One (1) digit
-
-   We also include a link to our [Terms and Conditions](https://cobalt.io/terms/general).
-
+1. From the page that appears, create a password. Follow the password complexity requirements on the screen. We also include a link to our [Terms and Conditions](https://cobalt.io/terms/general).
 1. Once you've set a password, you should see the Cobalt app.
-
 1. Next time you can sign in to Cobalt in the following ways:
    - From the {{% sign-in %}} page, with:
       - A username and password. Your username is your email address.

--- a/content/en/Getting started/Sign In/_index.md
+++ b/content/en/Getting started/Sign In/_index.md
@@ -77,7 +77,7 @@ We support two-factor authentication (2FA). If you're using [SAML SSO](#saml-sso
 {{% device-verification-intro %}}
 
 {{< alert title="Tip" color="primary" >}}
-If you see the **Verify It’s You** message upon signing in, follow the steps described in [We Can’t Recognize Your Device](/platform-deep-dive/cobalt-account/account-recovery/#we-cant-recognize-your-device).
+If you see the **Verify It's You** message upon signing in, follow the steps described in [We Don't Recognize Your Device](/platform-deep-dive/cobalt-account/account-recovery/#we-dont-recognize-your-device).
 {{< /alert >}}
 
 ## Next Step

--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -113,7 +113,9 @@ When you see the **Verify It's You** message upon signing in, do the following:
 
 1. Check your email that you used to sign in to Cobalt.
 1. In the email prompting you to verify your device, double-check the details of your last sign-in attempt, and select **Verify Device**.
-    - If you don't recognize this sign-in attempt, [change your password](/platform-deep-dive/cobalt-account/account-settings/#change-your-password), and [reset two-factor authentication](/platform-deep-dive/cobalt-account/account-settings/#reset-two-factor-authentication).
+    - If you don't recognize this sign-in attempt, do the following:
+       - Contact {{% csm-support %}}. We'll temporarily lock your account and open an investigation.
+       - [Change your password](/platform-deep-dive/cobalt-account/account-settings/#change-your-password), and [reset two-factor authentication](/platform-deep-dive/cobalt-account/account-settings/#reset-two-factor-authentication).
 1. We save the device information and sign you in to the Cobalt app.
     - You get an email confirming that we verified your new device.
     - Next time you sign in from this device, you don't need to verify it again.

--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -1,10 +1,10 @@
 ---
-title: "Account Recovery"
-linkTitle: "Account Recovery"
+title: "Troubleshoot Issues with Signing In"
+linkTitle: "Troubleshoot Sign-In Issues"
 weight: 20
 aliases: /getting-started/sign-in/account-recovery/
 description: >
-  Learn how to recover your Cobalt account.
+  Troubleshoot common issues with signing in.
 ---
 
 {{% pageinfo %}}
@@ -22,7 +22,8 @@ Follow these instructions if you can't sign in to Cobalt because:
   - [One-time codes](#one-time-codes-dont-work) don't work.
   - ["Remember this device" option](#remember-this-device-doesnt-work)  doesn't work.
 - You [forgot your password](#forgot-your-password).
-- You [can’t sign in using SAML SSO](#cant-sign-in-using-saml-sso).
+- [We can't recognize your device](#we-cant-recognize-your-device).
+- You have [problems with SAML SSO](#cant-sign-in-using-saml-sso).
 - You are [locked out of your account](#locked-out-of-your-account).
 - You believe [your account was compromised](#account-was-compromised).
 
@@ -98,6 +99,26 @@ To reset your password:
 1. On the {{% sign-in %}} page, select **Forgot password?**.
 1. Enter your email address that you used to [sign in to Cobalt](/getting-started/sign-in/), and select **Reset Password**.
 1. Follow the instructions in the email you receive.
+
+## We Can't Recognize Your Device
+
+When you sign in to Cobalt, we record information about your device.
+
+If you sign in from a device that we can't recognize, we take additional steps to verify your identity. This may happen when you:
+
+- Sign in from a new browser
+- Use your browser's private (incognito) mode
+- Clear your site data
+- Sign in from a different system
+
+When you see the **Verify It's You** message upon signing in, do the following:
+
+1. Check your email that you used to sign in to Cobalt.
+1. In the email prompting you to verify your device, double-check the details of your last sign-in attempt, and select **Verify Device**.
+    - If you don't recognize this sign-in attempt, [change your password](/platform-deep-dive/cobalt-account/account-settings/#change-your-password), and [reset two-factor authentication](/platform-deep-dive/cobalt-account/account-settings/#reset-two-factor-authentication).
+1. We save the device information and sign you in to the Cobalt app.
+    - You get an email confirming that we verified your new device.
+    - Next time you sign in from this device, you don't need to verify it again.
 
 ## Can't Sign In Using SAML SSO
 

--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -1,10 +1,10 @@
 ---
-title: "Troubleshoot Issues with Signing In"
-linkTitle: "Troubleshoot Sign-In Issues"
+title: "Troubleshoot Sign-in Issues"
+linkTitle: "Troubleshoot Sign-in Issues"
 weight: 20
 aliases: /getting-started/sign-in/account-recovery/
 description: >
-  Troubleshoot common issues with signing in.
+  Troubleshoot common sign-in issues.
 ---
 
 {{% pageinfo %}}
@@ -102,12 +102,7 @@ To reset your password:
 
 ## We Don't Recognize Your Device
 
-{{% device-verification-intro %}} This may happen when you:
-
-- Sign in from a new browser
-- Use your browser's private (incognito) mode
-- Clear your site data
-- Sign in from a different system
+{{% device-verification-intro %}}
 
 When you see the **Verify It's You** message upon signing in, do the following:
 

--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -22,7 +22,7 @@ Follow these instructions if you can't sign in to Cobalt because:
   - [One-time codes](#one-time-codes-dont-work) don't work.
   - ["Remember this device" option](#remember-this-device-doesnt-work)  doesn't work.
 - You [forgot your password](#forgot-your-password).
-- [We can't recognize your device](#we-cant-recognize-your-device).
+- [We don't recognize your device](#we-dont-recognize-your-device).
 - You have [problems with SAML SSO](#cant-sign-in-using-saml-sso).
 - You are [locked out of your account](#locked-out-of-your-account).
 - You believe [your account was compromised](#account-was-compromised).
@@ -100,7 +100,7 @@ To reset your password:
 1. Enter your email address that you used to [sign in to Cobalt](/getting-started/sign-in/), and select **Reset Password**.
 1. Follow the instructions in the email you receive.
 
-## We Can't Recognize Your Device
+## We Don't Recognize Your Device
 
 {{% device-verification-intro %}} This may happen when you:
 

--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -12,7 +12,7 @@ If you have problems signing in, refer to the instructions on this page. To get 
 {{% /pageinfo %}}
 
 {{< alert title="Tip" color="primary" >}}
-Before proceeding, ask your Organization Owner if SAML-based single sign-on (SSO) is enabled for your organization. If yes, sign in from the identity provider (IdP) system, not the Cobalt {{% sign-in %}} page. For more troubleshooting tips, see [Can’t Sign In Using SAML SSO](#cant-sign-in-using-saml-sso), below.
+Before proceeding, ask your Organization Owner if SAML-based single sign-on (SSO) is enabled for your organization. If yes, sign in from the identity provider (IdP) system, not the Cobalt {{% sign-in %}} page. For more troubleshooting tips, see [Can't Sign In Using SAML SSO](#cant-sign-in-using-saml-sso), below.
 {{< /alert >}}
 
 Follow these instructions if you can't sign in to Cobalt because:
@@ -114,7 +114,7 @@ When you see the **Verify It's You** message upon signing in, do the following:
 1. Check your email that you used to sign in to Cobalt.
 1. In the email prompting you to verify your device, double-check the details of your last sign-in attempt, and select **Verify Device**.
     - If you don't recognize this sign-in attempt, do the following:
-       - Contact {{% csm-support %}}. We'll temporarily lock your account and open an investigation.
+       - Contact {{% csm-support %}}. {{% compromised-account-action %}}
        - [Change your password](/platform-deep-dive/cobalt-account/account-settings/#change-your-password), and [reset two-factor authentication](/platform-deep-dive/cobalt-account/account-settings/#reset-two-factor-authentication).
 1. We save the device information and sign you in to the Cobalt app.
     - You get an email confirming that we verified your new device.
@@ -133,13 +133,13 @@ If your organization has enabled [SAML SSO](/getting-started/sign-in/#saml-sso),
 
 ## Locked Out of Your Account
 
-If you make several unsuccessful attempts to sign in, we’ll temporarily lock your account.
+If you make several unsuccessful attempts to sign in, we'll temporarily lock your account.
 
-To unlock your account, follow the instructions in the email that you receive. If you still can’t sign in, contact us at support@cobalt.io.
+To unlock your account, follow the instructions in the email that you receive. If you still can't sign in, contact us at support@cobalt.io.
 
 ## Account Was Compromised
 
-If you believe your account was compromised, reach out to {{% csm-support %}}. We'll open an investigation.
+If you believe your account was compromised, reach out to {{% csm-support %}}. {{% compromised-account-action %}}
 
 If you have access to your Cobalt account, do the following:
 

--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -116,6 +116,7 @@ When you see the **Verify It's You** message upon signing in, do the following:
     - If you don't recognize this sign-in attempt, do the following:
        - Contact {{% csm-support %}}. {{% compromised-account-action %}}
        - [Change your password](/platform-deep-dive/cobalt-account/account-settings/#change-your-password), and [reset two-factor authentication](/platform-deep-dive/cobalt-account/account-settings/#reset-two-factor-authentication).
+    - Make sure to verify your device before the link in the email expires.
 1. We save the device information and sign you in to the Cobalt app.
     - You get an email confirming that we verified your new device.
     - Next time you sign in from this device, you don't need to verify it again.

--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -102,9 +102,7 @@ To reset your password:
 
 ## We Can't Recognize Your Device
 
-When you sign in to Cobalt, we record information about your device.
-
-If you sign in from a device that we can't recognize, we take additional steps to verify your identity. This may happen when you:
+{{% device-verification-intro %}} This may happen when you:
 
 - Sign in from a new browser
 - Use your browser's private (incognito) mode
@@ -119,6 +117,8 @@ When you see the **Verify It's You** message upon signing in, do the following:
 1. We save the device information and sign you in to the Cobalt app.
     - You get an email confirming that we verified your new device.
     - Next time you sign in from this device, you don't need to verify it again.
+
+To enhance your account security, we recommend that you [enable two-factor authentication](/platform-deep-dive/cobalt-account/account-settings/#enable-two-factor-authentication).
 
 ## Can't Sign In Using SAML SSO
 

--- a/layouts/shortcodes/compromised-account-action.md
+++ b/layouts/shortcodes/compromised-account-action.md
@@ -1,0 +1,1 @@
+We'll temporarily lock your account and open an investigation.

--- a/layouts/shortcodes/device-verification-intro.md
+++ b/layouts/shortcodes/device-verification-intro.md
@@ -1,0 +1,3 @@
+When you sign in to Cobalt, we record information about your device to add an extra layer of security to the sign-in process.
+
+If you attempt to sign in from a device that we can't recognize, we take additional steps to verify your identity before granting you access.

--- a/layouts/shortcodes/device-verification-intro.md
+++ b/layouts/shortcodes/device-verification-intro.md
@@ -1,3 +1,3 @@
 When you sign in to Cobalt, we record information about your device to add an extra layer of security to the sign-in process.
 
-If you attempt to sign in from a device that we can't recognize, we take additional steps to verify your identity before granting you access.
+If you attempt to sign in from a device that we don't recognize, we take additional steps to verify your identity before granting you access.

--- a/layouts/shortcodes/device-verification-intro.md
+++ b/layouts/shortcodes/device-verification-intro.md
@@ -1,3 +1,8 @@
 When you sign in to Cobalt, we record information about your device to add an extra layer of security to the sign-in process.
 
-If you attempt to sign in from a device that we don't recognize, we take additional steps to verify your identity before granting you access.
+If you attempt to sign in from a device that we don't recognize, we take additional steps to verify your identity before granting you access. This may happen when you:
+
+- Sign in from a new browser
+- Use your browser's private (incognito) mode
+- Clear your site data
+- Sign in from a different system


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Troubleshoot Issues with Signing In > We Don't Recognize Your Device | https://deploy-preview-278--cobalt-docs.netlify.app/platform-deep-dive/cobalt-account/account-recovery/#we-dont-recognize-your-device | I changed the guide name. We're describing use cases beyond account recovery. |
| Sign In to Cobalt > Device Verification | https://deploy-preview-278--cobalt-docs.netlify.app/getting-started/sign-in/#device-verification | General overview |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
