### PR TITLE
[NO-TICKET] Update the branch name in a GitHub workflow

### DIFF
--- a/.github/workflows/check-branch-name.yml
+++ b/.github/workflows/check-branch-name.yml
@@ -4,7 +4,7 @@ on:
     branches:
       # All branches.
       - '**'        # Matches all branches.
-      - '!master'   # Excludes master.
+      - '!main'   # Excludes main.
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changelog

The GitHub workflow that checks the branch name always fails on the `main` branch because of the wrong branch name.

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| check-branch-name.yml |  | Changed `master` to `main` |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
