### PR TITLE
[DOCS-383] Update the Credits Threshold (12 Credits)

### DIFF
--- a/layouts/shortcodes/pentest-big-scope.md
+++ b/layouts/shortcodes/pentest-big-scope.md
@@ -1,1 +1,1 @@
-Pentests requiring more than 20 credits don’t get immediate credit confirmation. We’ll specify the number of required credits after reviewing the pentest.
+Pentests requiring more than 12 credits don’t get immediate credit confirmation. We’ll specify the number of required credits after reviewing the pentest.


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| 12 credits minimum threshold | https://deploy-preview-289--cobalt-docs.netlify.app/platform-deep-dive/pentests/pentest-types/ | `Pentests requiring more than 12 credits don’t get immediate credit confirmation. We’ll specify the number of required credits after reviewing the pentest.` |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
