### PR TITLE
[DOCS-380] Update the home page of the Product Docs portal

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,5 +1,4 @@
 ---
-title: "Overview of Cobalt Documentation"
 linkTitle: "Home"
 type: "docs"
 no_list: true
@@ -16,69 +15,81 @@ cascade:
     path: "/**"
 ---
 
-This page includes links to other Cobalt literature, including our
-[Getting Started](/getting-started/) guide.
-
-<br>
-<div class="mx-auto">
-        <a class="btn btn-lg btn-primary mr-3 mb-4" href="https://cobaltio.zendesk.com/hc/en-us/categories/360005476672-Cobalt-Platform">
-                Support Articles <i class="fas"></i>
-        </a>
-        <a class="btn btn-lg btn-outline-primary mr-3 mb-4" href="https://docs.cobalt.io">
-                API Docs <i class="fab"></i>
-        </a>
-        <a class="btn btn-lg btn-info mr-3 mb-4" href="https://cobalt.io/blog">
-                Blog Posts <i class="fab"></i>
-        </a>
+<div class="jumbotron px-5" style="background-color: #F8F9FB; margin-bottom: 4rem;">
+       <h1>Welcome to Cobalt Documentation</h1>
+       <p class="my-3">Deep dive into our documentation to explore Cobalt—your all-in-one platform for pentesting your software.</p>
+       <a class="btn btn-outline-primary rounded" href="https://www.cobalt.io/" target="_blank">Explore Cobalt »</a>
 </div>
 
-## Support Articles
+<div class="row g-4 my-3 px-5 row-cols-1 row-cols-lg-3">
+     <div class="feature col">
+       <div class="feature-icon d-inline-flex align-items-left justify-content-left text-bg-primary fs-2 mb-3">
+         <a href="/getting-started/" tabindex="-1"><img src="homepage/getting-started.svg"></a>
+       </div>
+       <h3 class="fs-2"><a href="/getting-started/">Getting Started</a></h3>
+       <p>Use our step-by-step guide to launch your first pentest. Set up an asset, specify pentest details—and get the ball rolling.</p>
+     </div>
+     <div class="feature col">
+       <div class="feature-icon d-inline-flex align-items-left justify-content-left text-bg-primary bg-gradient fs-2 mb-3">
+         <a href="/platform-deep-dive/pentests/pentest-process/methodologies/" tabindex="-1"><img src="homepage/methodologies.svg"></a>
+       </div>
+       <h3 class="fs-2"><a href="/platform-deep-dive/pentests/pentest-process/methodologies/">Methodologies</a></h3>
+       <p>Read about the methodologies that our pentesters use to test different types of assets: Web, API, Mobile, and more.</p>
+     </div>
+     <div class="feature col">
+       <div class="feature-icon d-inline-flex align-items-left justify-content-left text-bg-primary bg-gradient fs-2 mb-3">
+         <a href="/platform-deep-dive/pentests/pentest-types/" tabindex="-1"><img src="homepage/pentest-types.svg"></a>
+       </div>
+       <h3 class="fs-2"><a href="/platform-deep-dive/pentests/pentest-types/">Pentest Types</a></h3>
+       <p>Learn about the pentest types that we offer. Make your security stronger with Agile and Comprehensive Pentests.</p>
+     </div>
+   </div>
 
-When customers need help with the Cobalt app, they frequently rely on support articles, available through the [Cobalt Zendesk](https://cobaltio.zendesk.com/hc/en-us/categories/360005476672-Cobalt-Platform) interface.
+<div class="row my-3 g-4 px-5 row-cols-1 row-cols-lg-3" style="margin-bottom: 4rem;">
+     <div class="feature col">
+       <div class="feature-icon d-inline-flex align-items-left justify-content-left text-bg-primary fs-2 mb-3">
+         <a href="/platform-deep-dive/assets/" tabindex="-1"><img src="homepage/asset-types.svg"></a>
+       </div>
+       <h3 class="fs-2"><a href="/platform-deep-dive/assets/">Asset Types</a></h3>
+       <p>An asset is a software component of value to be tested, such as a web application or API. Explore the asset types we support.</p>
+     </div>
+     <div class="feature col">
+       <div class="feature-icon d-inline-flex align-items-left justify-content-left text-bg-primary bg-gradient fs-2 mb-3">
+         <a href="/integrations/" tabindex="-1"><img src="homepage/integrations.svg"></a>
+       </div>
+       <h3 class="fs-2"><a href="/integrations/">Integrations</a></h3>
+       <p>Integrate third-party apps to streamline your workflows, and configure webhooks to get real-time pentest updates.</p>
+     </div>
+     <div class="feature col">
+       <div class="feature-icon d-inline-flex align-items-left justify-content-left text-bg-primary bg-gradient fs-2 mb-3">
+         <a href="/product-updates/" tabindex="-1"><img src="homepage/whats-new.svg"></a>
+       </div>
+       <h3 class="fs-2"><a href="/product-updates/">What’s New</a></h3>
+       <p>We regularly ship updates to the Cobalt platform. Read our monthly release blog to stay on top of the latest news.</p>
+     </div>
+   </div>
 
-If you're a Cobalt customer, connect to Zendesk and select the **Sign in** link.
-Once connected, you'll have access to more support articles.
 
-## API Documentation
+<div class="row align-items-md-stretch my-5">
+      <div class="col-md-6">
+        <div class="h-100 p-5 border rounded-lg" style="border-color: #D6E3FD">
+          <h3>Preview Risk Advisories</h3>
+          <p class="my-2">{{% new-label %}}</p>
+          <p>Add a technology stack for your software asset, and we'll show you a preview of risk advisories based on the Common Vulnerabilities and Exposures (CVE) standard for that stack. Subscribe to email alerts <img title="Bell icon" alt="Bell icon" src="/icons/Bell.png"> for potential critical vulnerabilities discovered in your assets.</p>
+          <a href="/platform-deep-dive/assets/risk-advisories/">Read the guide »</a>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="h-100 p-5 border rounded-lg" style="border-color: #D6E3FD">
+          <h3>Try Beta Integrations</h3>
+          <p class="my-2">{{% beta-label %}}</p>
+          <p>Request to <a href="/integrations/#request-a-beta-integration">enable a beta integration for your next pentest</a> to streamline your remediation workflows. Customize the configuration to suit your needs, and start pushing Cobalt findings to your preferred task management software: Azure DevOps, Bitbucket, or ServiceNow.</p>
+       <a href="https://docs.google.com/forms/d/e/1FAIpQLScMNMnpIvJRNxEziIBCu246g_YqMuGU052XE-Q-gVh3mjy9XQ/viewform" target="_blank">Request an integration »</a><br>
+        </div>
+      </div>
+    </div>
 
-Cobalt has a [RESTful API](https://docs.cobalt.io)
-that allows you to call the following data related to your pentests:
-
-- Organizations
-- Assets
-- Pentests
-- Findings
-- Events
-- Tokens
-
-To use our REST calls, you'll need an API Token from your
-[Cobalt profile](https://app.cobalt.io/settings/api-token).
-
-
-## Blog Posts
-
-Cobalt has an extensive library of [blog posts](https://cobalt.io/blog),
-designed to help and inform you about:
-
-- Cobalt and our product
-- Profiles for our pentesters
-- Advice for our customers
-- Standards and how you can meet them
-- Life at Cobalt
-
-<!--
-Suggestion from Grahame: I know it's early days, but could be cool to link to a few of these articles. 
-Especially any that are specifically relevant to the API. 
-(Customer testimonials could also be good, in case anyone's coming to the API first.)
--->
-
-{{% pageinfo %}}
-Cobalt is creating product documentation. As we build it, we hope to help you
-visualize how our product can help you simplify the pentest process.
-
-We hope that future docs can help you make best use of Cobalt software.
-{{% /pageinfo %}}
-
-This documentation is a product of Cobalt Labs, Inc. As noted in our
-[Terms of use](https://cobalt.io/terms/general), when we use "Us", "We", "Our", "Cobalt.io",
-or "Cobalt, we're referring to Cobalt Labs, Inc., a Delaware Corporation.
+<div class="text mx-5">
+  <h3>Need More Help? Get in Touch!</h3>
+  <p>If you need help, don't hesitate to contact us.</p><ul><li>If you have a named Customer Success Manager, get in touch with them.</li><li>Otherwise, <a href="https://cobaltio.zendesk.com/hc/en-us/requests/new" target="_blank">submit a ticket</a> or send an email to <a href="mailto:support@cobalt.io" target="_blank">support@cobalt.io</a>.</ul>
+</div>


### PR DESCRIPTION
## Changelog

### Added

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
