### PR TITLE
[NO-TICKET] Troubleshoot SAML SSO Configuration

### DIFF
--- a/content/en/Platform Deep Dive/Collaboration/Organization/Organization Settings/saml-sso.md
+++ b/content/en/Platform Deep Dive/Collaboration/Organization/Organization Settings/saml-sso.md
@@ -32,6 +32,7 @@ Configuration procedures differ for each identity provider. Here’s the general
     - Navigate to the **Settings** page, and then select **Identity & Access**.
     - Under **SAML 2.0**, select **Enable**.
     - Enter parameter values that you obtained from the identity provider, and select **Save**.
+        - For the **IdP Certificate**, make sure to include `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.
     - Save the **IdP RelayState** value that appears in red.<br><br>
     ![Configure SAML SSO in the Cobalt app](/deepdive/ConfigureSAML.png "Configure SAML SSO in the Cobalt app")
 1. Complete the integration in the identity provider system, and test the connection.
@@ -50,7 +51,7 @@ To get help, contact your Customer Success Manager (CSM) or support@cobalt.io. W
 
 | Troubleshooting Tip | Details |
 |---|---|
-| Ensure that the IdP certificate is accurate. | Copy the IdP certificate once again. Make sure there are no extra whitespaces. |
+| Ensure that the IdP certificate is accurate. | Copy the IdP certificate once again.<br>• Include `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.<br>• Make sure there are no extra whitespaces. |
 | Check that the organization tokens (**IdP Relay State** in Cobalt) match in the IdP system and Cobalt. Pay attention to quotation marks. | Check that all quotation marks in the organization tokens are straight quotes `" "` and not curly quotes `“ ”`. |
 | Ensure that you added users to the Cobalt platform. | We don’t support user provisioning through an IdP. When leveraging an IdP, make sure that there is an established identity for a user in Cobalt.<br>To establish an identity in Cobalt, a user needs to create a password and sign in to Cobalt. All subsequent sign-ins (after the user identity is established in Cobalt) are initiated through the organization’s IdP. |
 | Ensure that the IdP issuer URL value matches between your identity provider and Cobalt. | The Issuer/Identifier ID in a SAML assertion doesn’t have to be a valid URL path. For [Okta](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Cobalt.html), the IdP issuer URL must start with `http` not `https`.  |


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Configure SAML SSO | https://deploy-preview-307--cobalt-docs.netlify.app/platform-deep-dive/collaboration/organization/organization-settings/saml-sso/ | Minor update about the certificate |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
