### PR TITLE
[DOCS-407] Downgrade Hugo version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"   
   
 [build.environment]
-HUGO_VERSION = "0.110.0"
+HUGO_VERSION = "0.109.0"
 HUGO_ENV = "production"
 
 [[redirects]]


### PR DESCRIPTION
## Changelog

Downgrade the Hugo version from 0.110.0 to 0.109.0 to avoid possible problems with the config.toml file.

More info in [Hugo release notes](https://github.com/gohugoio/hugo/releases/tag/v0.110.0).

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
