### PR TITLE
[NO-TICKET] Okta guide update

### DIFF
--- a/content/en/Platform Deep Dive/Collaboration/Organization/Organization Settings/SAML SSO/okta.md
+++ b/content/en/Platform Deep Dive/Collaboration/Organization/Organization Settings/SAML SSO/okta.md
@@ -32,10 +32,10 @@ For more information on the listed features, visit the [Okta Glossary](https://h
 
 ## Configuration Steps
 
-1. Sign in to Cobalt, and go to **Settings** > **Security**. You should have an [Organization Owner](/getting-started/glossary/#organization-owner) role.
+1. Sign in to Cobalt, and go to **Settings** > **Identity & Access**. You should have an [Organization Owner](/getting-started/glossary/#organization-owner) role.
 1. Under **Configure SAML**, click **Configure**. An overlay for configuring SAML opens.<br><br>
     ![SAML SSO configuration overlay in the Cobalt app](/deepdive/configure-SAML-overlay.png "SAML SSO configuration overlay in the Cobalt app")
-1. Enter the following values from Okta. In the Okta Admin Dashboard, select the **Sign On** tab for the Cobalt SAML app, then click **Edit**.
+1. Enter the following values from Okta. In the Okta Admin Dashboard, select the **Sign On** tab for the Cobalt SAML app, then click **Edit**. Under **Metadata details**, click **More details**.
     - **IdP SSO URL**: Enter **Sign on URL**.
     - **IdP Certificate**: Enter **Signing Certificate**. Download the certificate, and copy the file contents including `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.
     - Click **Save Configuration**.<br><br>


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link |  |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
