### PR TITLE
[DOCS-440] SAML enforcement

### DIFF
--- a/content/en/Platform Deep Dive/Collaboration/Organization/Organization Settings/SAML SSO/_index.md
+++ b/content/en/Platform Deep Dive/Collaboration/Organization/Organization Settings/SAML SSO/_index.md
@@ -42,7 +42,7 @@ If you have problems setting up SAML SSO, see our [troubleshooting tips](#troubl
 
 ## Enforce SAML SSO
 
-SAML SSO enforcement reqiures organization users to sign in to Cobalt only through [SAML SSO](/getting-started/glossary/#saml-single-sign-on-sso). Once the enforcement is on, other authentication methods will no longer work. This affects the following roles:
+SAML SSO enforcement reqiures organization users to sign in to Cobalt only through SAML SSO. Once the enforcement is on, other authentication methods will no longer work. This affects the following roles:
 
 {{% owner-member-team-member %}}
 

--- a/content/en/Platform Deep Dive/Collaboration/Organization/Organization Settings/SAML SSO/_index.md
+++ b/content/en/Platform Deep Dive/Collaboration/Organization/Organization Settings/SAML SSO/_index.md
@@ -32,6 +32,7 @@ Here’s a general configuration workflow:
     ![Configure SAML SSO in the Cobalt app](/deepdive/ConfigureSAML.png "Configure SAML SSO in the Cobalt app")
 1. Complete the integration in the identity provider system, and test the connection.
     - Test your SAML configuration in an incognito window before signing out of Cobalt. This will prevent any account lockout.
+1. If the test is successful, [enforce SAML](#enforce-saml-sso) for all users.
 
 We don’t synchronize user datastores, so make sure that all users:
 

--- a/content/en/Platform Deep Dive/Collaboration/Organization/Organization Settings/SAML SSO/_index.md
+++ b/content/en/Platform Deep Dive/Collaboration/Organization/Organization Settings/SAML SSO/_index.md
@@ -40,6 +40,18 @@ We don’t synchronize user datastores, so make sure that all users:
 
 If you have problems setting up SAML SSO, see our [troubleshooting tips](#troubleshoot-your-saml-sso-configuration).
 
+## Enforce SAML SSO
+
+SAML SSO enforcement reqiures organization users to sign in to Cobalt only through [SAML SSO](/getting-started/glossary/#saml-single-sign-on-sso). Once the enforcement is on, other authentication methods will no longer work. This affects the following roles:
+
+{{% owner-member-team-member %}}
+
+To enforce SAML SSO for your organization:
+
+1. Navigate to **Settings** > **Identity & Access**. You must have SAML SSO configured.
+1. Under **SAML 2.0**, turn on the **Enforce SAML** toggle, and confirm your action.
+1. Notify users that now they must sign in through the selected identity provider. We don't send any notifications, so make sure that SAML enforcement doesn't disrupt your workflows.
+
 ## Configuration Instructions for Specific Identity Providers
 
 **You can configure SAML SSO with your preferred identity provider**. Here are instructions for some popular IdPs:

--- a/content/en/Platform Deep Dive/Collaboration/Organization/Organization Settings/SAML SSO/_index.md
+++ b/content/en/Platform Deep Dive/Collaboration/Organization/Organization Settings/SAML SSO/_index.md
@@ -32,7 +32,9 @@ Here’s a general configuration workflow:
     ![Configure SAML SSO in the Cobalt app](/deepdive/ConfigureSAML.png "Configure SAML SSO in the Cobalt app")
 1. Complete the integration in the identity provider system, and test the connection.
     - Test your SAML configuration in an incognito window before signing out of Cobalt. This will prevent any account lockout.
-1. If the test is successful, [enforce SAML](#enforce-saml-sso) for all users.
+1. If the test is successful, assign users to the SAML app in the IdP.
+1. [Enforce SAML](#enforce-saml-sso) for all users.
+1. Notify users that now they must sign in through the selected identity provider. We don't send any notifications to users.
 
 We don’t synchronize user datastores, so make sure that all users:
 


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| SAML SSO | [Link](https://deploy-preview-344--cobalt-docs.netlify.app/platform-deep-dive/collaboration/organization/organization-settings/saml-sso/#enforce-saml-sso) | Added info about SAML enforcement |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
