### PR TITLE
[DOCS-454] Password Best Practices

### DIFF
--- a/content/en/Getting started/sign-in.md
+++ b/content/en/Getting started/sign-in.md
@@ -15,7 +15,7 @@ Learn about your first steps with Cobalt after receiving a welcome email.
 Once you've received a welcome email from Cobalt, do the following:
 
 1. Select **Sign In** in the email.
-1. Create a password. Follow the password complexity requirements on the screen.
+1. Create a strong password. To learn more, read our [password best practices](/platform-deep-dive/cobalt-account/password-best-practices/).
 
 Once you've confirmed your email address and created a password, your Cobalt account is fully set up.
 

--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -84,7 +84,7 @@ To reset your password:
 
 1. On the {{% sign-in %}} page, select **Forgot password?**.
 1. Enter your email address that you used to [sign in to Cobalt](/getting-started/sign-in/), and select **Reset Password**.
-1. Follow the instructions in the email you receive.
+1. Follow the instructions in the email you receive. Learn [how to create a strong password](/platform-deep-dive/cobalt-account/password-best-practices/).
 
 ## We Don't Recognize Your Device
 

--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -41,7 +41,7 @@ You can change your password by resetting it.
 
 1. Navigate to https://app.cobalt.io/settings/account.
 1. Select **Change Password**.
-1. Follow the instructions in the email that you receive to reset your password.
+1. Follow the instructions in the email that you receive to reset your password. Learn [how to create a strong password](/platform-deep-dive/cobalt-account/password-best-practices/).
 
 If you're using Google authentication (OAuth 2.0), sign in with your email and password, and then change your password.
 

--- a/content/en/Platform Deep Dive/Cobalt Account/password-best-practices.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/password-best-practices.md
@@ -1,0 +1,56 @@
+---
+title: "Password Best Practices"
+linkTitle: "Password Best Practices"
+weight: 40
+description: >
+  Learn how to create a strong password.
+---
+
+{{% pageinfo %}}
+Follow best practices when creating a password for your Cobalt account. A strong password helps you protect your account from unauthorized access.
+{{% /pageinfo %}}
+
+## Create a Strong Password
+
+**Cobalt password requirements**:
+
+- The password must contain:
+  - At least 10 characters
+  - At least 3 of the following:
+  - Lowercase letters: a–z
+  - Uppercase letters: A–Z
+  - Numbers: 0–9
+  - Special characters: !@#$%^&*
+- We don't allow common passwords such as `password`, `123456`, or `qwerty`.
+
+Example of a strong password: `1$WinterIsComing$1` (don't use this example).
+
+**How to create a strong password**:
+
+- Use a unique passphrase that you can memorize but no one else can guess, such as an abbreviation made from the first letters of your favorite quote.
+- Use a long passphrase that you can memorize. The longer your password is, the harder it is for an attacker to compromise it.
+- If you find it difficult to remember multiple unique passwords, use a trusted password management tool.
+
+**Avoid the following**:
+
+- Sharing your passwords with anyone.
+- Reusing one password on multiple accounts. If an attacker compromises one of your accounts, they can access your other accounts using the same password.
+- Writing your passwords down. If you have no other choice, store your written passwords in a secret place that no one else knows about.
+- Using common words and patterns:
+  - Keyboard patterns, such as `qwerty` or `123456`
+  - Special characters instead of letters, such as in `P@ssw0rd`
+  - Obvious words, such as `password` or `mypass`
+- Using passwords that contain easily accessible information. A threat actor can guess your password if they know your personal data, such as:
+  - Your name or birthday
+  - Names or birthdays of your family members
+  - Your phone number or email address
+  - Your Social Security Number or ID number
+
+## Protect Your Account
+
+To add an extra layer of security to your account, enable [two-factor authentication (2FA)](/platform-deep-dive/cobalt-account/account-settings/#two-factor-authentication). 2FA only works when you sign in with your email and password.
+
+As an [Organization Owner](/getting-started/glossary/#organization-owner), you can enhance the security of user accounts within your organization:
+
+- [Enforce 2FA](/platform-deep-dive/organization/organization-settings/enforce-2fa/).
+- [Enable SAML single sign-on (SSO)](/platform-deep-dive/organization/organization-settings/saml-sso/). You can also [enforce SAML](/platform-deep-dive/organization/organization-settings/saml-sso/#enforce-saml-sso) to require users to authenticate only through SAML SSO.

--- a/content/en/Platform Deep Dive/Cobalt Account/password-best-practices.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/password-best-practices.md
@@ -17,10 +17,10 @@ Follow best practices when creating a password for your Cobalt account. A strong
 - The password must contain:
   - At least 10 characters
   - At least 3 of the following:
-  - Lowercase letters: a–z
-  - Uppercase letters: A–Z
-  - Numbers: 0–9
-  - Special characters: !@#$%^&*
+    - Lowercase letters: a–z
+    - Uppercase letters: A–Z
+    - Numbers: 0–9
+    - Special characters: !@#$%^&*
 - We don't allow common passwords such as `password`, `123456`, or `qwerty`.
 
 Example of a strong password: `1$WinterIsComing$1` (don't use this example).


### PR DESCRIPTION
## Changelog

### Added

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Password Best Practices | [Link](https://deploy-preview-375--cobalt-docs.netlify.app/platform-deep-dive/cobalt-account/password-best-practices/) | |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
