### PR TITLE
[DOCS-441] Asset tags

### DIFF
--- a/content/en/Getting started/Assets/_index.md
+++ b/content/en/Getting started/Assets/_index.md
@@ -32,7 +32,8 @@ The **Asset** screen prompts you for the following information:
 - [Asset Type](/getting-started/assets/asset-type/): Select one of the options described in the linked page.
 - [Technology Stack](/platform-deep-dive/assets/risk-advisories/#add-a-technology-stack-for-your-asset) (for Web, Mobile, API, and combined asset types): Add a technology stack for your asset. You can preview [potential vulnerabilities](/platform-deep-dive/assets/risk-advisories/) based on the [Common Vulnerabilities and Exposures (CVE)](https://www.cve.org/) standard for this stack.
 - [Asset Description](/getting-started/assets/asset-description/): Add information that can help your pentesters fully analyze your asset.
-- [Attachment(s)](/getting-started/assets/asset-description/#attachments): Upload documentation, architecture diagrams, images, spreadsheets, or videos related to your asset.
+- [Attachments](/getting-started/assets/asset-description/#attachments): Upload documentation, architecture diagrams, images, spreadsheets, or videos related to your asset.
+- **Tags**: A tag is a custom asset identifier in a third-party system. Add tags to map your assets to external systems, such as your vulnerability management application or task tracking system.
 
 ![Specify asset details](/gsg/AssetScreen.png "Specify asset details")
 

--- a/content/en/Getting started/Assets/asset-description.md
+++ b/content/en/Getting started/Assets/asset-description.md
@@ -24,7 +24,7 @@ For all assets, we'd appreciate a:
 
 Include links to published documentation related to the
 asset. You can upload documentation, diagrams, and more in various
-file formats under [Attachment(s)](#attachments).
+file formats under [Attachments](#attachments).
 
 The following sections detail additional needs for different kinds of assets:
 

--- a/content/en/Getting started/glossary.md
+++ b/content/en/Getting started/glossary.md
@@ -51,6 +51,12 @@ following categories:
 
 {{% asset-categories %}}
 
+## Asset Tag
+
+Custom asset identifier in a third-party system. As a customer, you can add tags to Cobalt assets to map them to external systems, such as your vulnerability management application or task tracking system.
+
+Learn more about [creating assets](/getting-started/assets/).
+
 ## Application Security (AppSec)
 
 Application security is the practice of using security software, hardware, techniques,

--- a/layouts/shortcodes/asset-best-practices.md
+++ b/layouts/shortcodes/asset-best-practices.md
@@ -4,3 +4,4 @@
 - Add a product walk-through and asset documentation using the [provided templates](/getting-started/assets/asset-description/#attachments).
 - Keep your assets up to date.
 - Start creating or editing your asset before creating a pentest. You can reuse the asset for future pentests.
+- Use tags to map your assets to external systems.


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
