### PR TITLE
[NO-TICKET] Okta gallery app for Cobalt

### DIFF
--- a/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/_index.md
+++ b/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/_index.md
@@ -190,19 +190,16 @@ To create a SAML app for Cobalt in the Google Admin console:
 
 ### Okta
 
-<!--You can set up SAML SSO with Okta in two ways:
+You can set up SAML SSO with Okta in two ways:
 
-- Use the [gallery Cobalt app](https://www.okta.com/integrations/cobalt/) in Okta. Learn [how to configure SAML using the gallery Cobalt app](/platform-deep-dive/organization/organization-settings/saml-sso/okta/).
-- _(Recommended)_ Create a non-gallery SAML app for Cobalt manually. To learn more, read Okta's [documentation](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml).
+- Use the **gallery SAML app for Cobalt**. Learn [how to configure SAML using the gallery app](/platform-deep-dive/organization/organization-settings/saml-sso/okta/).
+- Create a **non-gallery SAML app** for Cobalt manually. Follow the instructions below.
 
-If you create an application for Okta **manually**, use the following parameters.-->
-
-Create a **non-gallery SAML application** for Cobalt manually. For more information, refer to Okta [documentation](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml).
-
-Currently, the Cobalt gallery app in Okta doesn't support new SAML settings.
-
-{{%expand "Click to view instructions." %}}
+{{%expand "Click to view instructions for a non-gallery SAML app." %}}
 <br>
+
+For more information on how to create a non-gallery app, refer to the Okta [documentation](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml).
+
 To create a non-gallery SAML app for Cobalt in Okta:
 
 1. In Cobalt, go to **Settings** > **Identity & Access**. Under **Configure SAML**, select **Configure**. You will need the following values in the next steps:

--- a/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/okta.md
+++ b/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/okta.md
@@ -8,7 +8,7 @@ description: >
 ---
 
 {{% pageinfo %}}
-This guide is for Organization Owners who configure SAML with Okta as an identity provider (IdP) using the **[gallery Cobalt SAML app](https://www.okta.com/integrations/cobalt/)**.
+This guide is for Organization Owners who configure SAML with Okta as an identity provider (IdP) using the [gallery Cobalt SAML app](https://www.okta.com/integrations/cobalt/).
 
 If you want to [create a non-gallery application for Okta](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml) manually, see [how to set up the configuration](/platform-deep-dive/organization/organization-settings/saml-sso/#okta).
 {{% /pageinfo %}}

--- a/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/okta.md
+++ b/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/okta.md
@@ -2,16 +2,15 @@
 title: "How to Configure SAML 2.0 for Cobalt"
 linkTitle: "Okta: Gallery Cobalt App"
 weight: 30
-toc_hide: true
 aliases: /platform-deep-dive/collaboration/organization/organization-settings/saml-sso/okta/
 description: >
   Configure SAML with Okta using their gallery app for Cobalt.
 ---
 
 {{% pageinfo %}}
-**Disclaimer:** This guide is not relevant until June 21, 2023.
+This guide is for Organization Owners who configure SAML with Okta as an identity provider (IdP) using the **[gallery Cobalt SAML app](https://www.okta.com/integrations/cobalt/)**.
 
-This guide is for Organization Owners who configure SAML with Okta as an identity provider (IdP) using the **[gallery Cobalt SAML app](https://www.okta.com/integrations/cobalt/)**. If you want to [create a non-gallery application for Okta](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml) manually, see [how to set up the configuration](/platform-deep-dive/organization/organization-settings/saml-sso/#okta).
+If you want to [create a non-gallery application for Okta](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml) manually, see [how to set up the configuration](/platform-deep-dive/organization/organization-settings/saml-sso/#okta).
 {{% /pageinfo %}}
 
 If your organization [enforces SAML](/platform-deep-dive/organization/organization-settings/saml-sso/#enforce-saml-sso) in Cobalt, users will no longer be able to authenticate through the sign-in page. They must authenticate to Cobalt only through the Okta service.

--- a/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/saml-migration.md
+++ b/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/saml-migration.md
@@ -106,20 +106,12 @@ To update your existing SAML configuration with Google:
 
 #### Okta
 
-<!--
-Instructions differ depending on how you've set up your Cobalt SAML app in Okta:
+Instructions differ depending on how you've set up your Cobalt SAML app in Okta. Click <i style="font-size:x-large; color: #0047AB" class="fas fa-chevron-right"></i> to view instructions.
 
-- [Non-gallery app](#non-gallery-saml-app-for-cobalt)
-- [Gallery app for Cobalt](#gallery-saml-app-for-cobalt)
+{{%expand "Non-gallery SAML app" %}}
+<br>
 
-##### Non-gallery SAML App for Cobalt
-
-Learn how to update your existing SAML configuration with Okta for a non-gallery Cobalt SAML app.
--->
-
-Learn how to update your existing SAML configuration with Okta.
-
-{{%expand "Click to view instructions." %}}
+To update your existing SAML configuration with Okta for a non-gallery SAML app:
 
 1. In Cobalt, go to **Settings** > **Identity & Access**. Under **Configure SAML**, select **Configure**.
     - Copy the **ACS URL**.<br><br>
@@ -138,16 +130,11 @@ Learn how to update your existing SAML configuration with Okta.
     - **IdP Certificate**: Enter the **Signing Certificate** from Okta.
     - Select **Save Configuration**.
 {{% /expand %}}
+
+{{%expand "Gallery SAML app for Cobalt" %}}
 <br>
 
-If you want to set up a new application, follow this [instruction](/platform-deep-dive/organization/organization-settings/saml-sso/#okta).
-
-<!--
-##### Gallery SAML App for Cobalt
-
-Learn how to update your existing SAML configuration with Okta for a [gallery Cobalt SAML app](https://www.okta.com/integrations/cobalt/).
-
-{{%expand "Click to view instructions." %}}
+To update your existing SAML configuration with Okta for a [gallery SAML app for Cobalt](https://www.okta.com/integrations/cobalt/):
 
 1. In Cobalt, go to **Settings** > **Identity & Access**. Under **Configure SAML**, select **Configure**.
     - Copy the organization's **slug** that appears after `=` in the ACS URL. You can also see the slug in **Settings** > **General**.<br><br>
@@ -168,7 +155,9 @@ Learn how to update your existing SAML configuration with Okta for a [gallery Co
     - Select **Save Configuration**.<br><br>
     ![Update your SAML configuration in a gallery Cobalt SAML app](/deepdive/Cobalt-configuration-for-Okta-preintegrated-app-2.png "Update your SAML configuration in a gallery Cobalt SAML app")
 {{% /expand %}}
--->
+<br>
+
+If you want to set up a new application, follow this [instruction](/platform-deep-dive/organization/organization-settings/saml-sso/#okta).
 
 #### OneLogin
 


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| How to Configure SAML 2.0 for Cobalt | [Link](https://deploy-preview-391--cobalt-docs.netlify.app/platform-deep-dive/organization/organization-settings/saml-sso/okta/) |  |
| Configure SAML SSO > Okta | [Link](https://deploy-preview-391--cobalt-docs.netlify.app/platform-deep-dive/organization/organization-settings/saml-sso/#okta) | Intro |
| Update SAML SSO > Okta | [Link](https://deploy-preview-391--cobalt-docs.netlify.app/platform-deep-dive/organization/organization-settings/saml-sso/saml-migration/#okta) | |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
