### PR TITLE
[FND-3199] Fix SAML SSO docs for Azure AD

### DIFF
--- a/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/_index.md
+++ b/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/_index.md
@@ -111,13 +111,11 @@ To configure SAML SSO with Azure Active Directory (Azure AD):
        - **Relay State**: Leave this field.
        - **Logout URL**: Leave this field blank.
     - Under **User Attributes & Claims**, add custom attribute mappings to your SAML token attributes configuration.
-       - **givenname**: `user.givenname`
-       - **surname**: `user.surname`
-       - **emailaddress**: `user.mail`
+       - **email**: `user.mail`
        - **name**: `user.userprincipalname`
        - **Unique User Identifier**: `user.userprincipalname`
     - The Cobalt app expects the following attributes to be passed in the SAML response:
-       <table style="border: 1px solid #E0E2E6; padding: 5px;"><thead><tr><th style="border: 1px solid #E0E2E6; padding: 5px;">Name</th><th style="border: 1px solid #E0E2E6; padding: 5px;">Source Attribute</th></tr></thead><tbody><tr><td style="border: 1px solid #E0E2E6; padding: 5px;"><code>Mail</code></td><td style="border: 1px solid #E0E2E6; padding: 5px;"><code>user.mail</code></td></tr><tr><td style="border: 1px solid #E0E2E6; padding: 5px;"><code>Othermail</code></td><td style="border: 1px solid #E0E2E6; padding: 5px;"><code>user.othermail</code></td></tr></tbody></table>
+       <table style="border: 1px solid #E0E2E6; padding: 5px;"><thead><tr><th style="border: 1px solid #E0E2E6; padding: 5px;">Name</th><th style="border: 1px solid #E0E2E6; padding: 5px;">Source Attribute</th></tr></thead><tbody><tr><td style="border: 1px solid #E0E2E6; padding: 5px;"><code>email</code></td><td style="border: 1px solid #E0E2E6; padding: 5px;"><code>user.mail</code></td></tr></tbody></table>
     - Under **SAML Signing Certificate**, download **Certificate (Base 64)**.
     - Under **Set up [Your App]**, copy **Login URL**.
 1. In Cobalt, go to **Settings** > **Identity & Access**. Under **Configure SAML**, select **Configure**.


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Configure SAML SSO |  | Fixed docs for Azure AD |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
