### PR TITLE
Show Okta Gallery App Instructions within SAML Configs

### DIFF
--- a/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/_index.md
+++ b/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/_index.md
@@ -191,10 +191,16 @@ To create a SAML app for Cobalt in the Google Admin console:
 
 ### Okta
 
-For more information, refer to the Okta [documentation](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml).
+You can set up SAML SSO with Okta in two ways:
 
-{{%expand "Click to view instructions." %}}
+- Use the **gallery SAML app for Cobalt**. Learn [how to configure SAML using the gallery app](/platform-deep-dive/organization/organization-settings/saml-sso/okta/).
+- Create a **non-gallery SAML app** for Cobalt manually. Follow the instructions below.
+
+{{%expand "Click to view instructions for a non-gallery SAML app." %}}
 <br>
+
+For more information on how to create a non-gallery app, refer to the Okta [documentation](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml).
+
 To create a non-gallery SAML app for Cobalt in Okta:
 
 1. In Cobalt, go to **Settings** > **Identity & Access**. Under **Configure SAML**, select **Configure**. You will need the following values in the next steps:

--- a/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/_index.md
+++ b/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/_index.md
@@ -193,6 +193,8 @@ To create a SAML app for Cobalt in the Google Admin console:
 
 For more information, refer to the Okta [documentation](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml).
 
+{{%expand "Click to view instructions." %}}
+<br>
 To create a non-gallery SAML app for Cobalt in Okta:
 
 1. In Cobalt, go to **Settings** > **Identity & Access**. Under **Configure SAML**, select **Configure**. You will need the following values in the next steps:
@@ -224,6 +226,8 @@ To create a non-gallery SAML app for Cobalt in Okta:
     - **IdP Certificate**: Enter **Signing Certificate** from Okta.
 1. Test the integration.
 1. If the test is successful, assign users to the application.
+
+{{% /expand %}}
 
 ### OneLogin
 

--- a/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/okta.md
+++ b/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/okta.md
@@ -53,4 +53,4 @@ The following SAML attributes are supported:
 
 | Name      | Value          |
 | --------- | -------------- |
-| email     | user.userName     |
+| email     | user.email     |

--- a/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/okta.md
+++ b/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/okta.md
@@ -1,0 +1,56 @@
+---
+title: "How to Configure SAML 2.0 for Cobalt"
+linkTitle: "Okta: Gallery Cobalt App"
+weight: 30
+aliases: /platform-deep-dive/collaboration/organization/organization-settings/saml-sso/okta/
+description: >
+  Configure SAML with Okta using their gallery app for Cobalt.
+---
+
+{{% pageinfo %}}
+This guide is for Organization Owners who configure SAML with Okta as an identity provider (IdP) using the [gallery Cobalt SAML app](https://www.okta.com/integrations/cobalt/).
+
+If you want to [create a non-gallery application for Okta](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml) manually, see [how to set up the configuration](/platform-deep-dive/organization/organization-settings/saml-sso/#okta).
+{{% /pageinfo %}}
+
+If your organization [enforces SAML](/platform-deep-dive/organization/organization-settings/saml-sso/#enforce-saml-sso) in Cobalt, users will no longer be able to authenticate through the sign-in page. They must authenticate to Cobalt only through the Okta service.
+
+## Contents
+
+- [Supported Features](#supported-features)
+- [Configuration Steps](#configuration-steps)
+- [Notes](#notes)
+
+## Supported Features
+
+The Okta/Cobalt SAML integration supports the following features:
+
+- IdP-initiated SSO
+
+For more information on the listed features, visit the [Okta Glossary](https://help.okta.com/en/prod/Content/Topics/Reference/glossary.htm).
+
+## Configuration Steps
+
+1. Sign in to Cobalt, and go to **Settings** > **Identity & Access**. You should have an [Organization Owner](/platform-deep-dive/collaboration/user-roles/#organization-owner) role.
+1. Under **Configure SAML**, click **Configure**. An overlay for configuring SAML opens.<br><br>
+    ![SAML SSO configuration overlay in the Cobalt app](/deepdive/configure-SAML-overlay.png "SAML SSO configuration overlay in the Cobalt app")
+1. In Cobalt, enter the following values from Okta. In the Okta Admin Dashboard, select the **Sign On** tab for the Cobalt SAML app, then click **Edit**. Under **Metadata details**, click **More details**.
+    - **IdP SSO URL**: Enter the **Sign on URL** from Okta.
+    - **IdP Certificate**: Enter the **Signing Certificate** from Okta.
+    - Click **Save Configuration**.<br><br>
+    ![Set the Application username format in Okta](/deepdive/Okta-SAML-configurations.png "Set the Application username format in Okta")
+1. In Okta, select the **Sign On** tab for the Cobalt SAML app, then click **Edit**.
+    - **Slug**: Enter your organization’s slug from Cobalt. The slug appears after `=` in the ACS URL. You can also find the slug in **Settings** > **General**.<br><br>
+    ![Organization's slug in the ACS URL](/deepdive/slug-acs-url.png "Organization's slug in the ACS URL")
+    - **Application username format**: Select **Email**.<br><br>
+    ![Set the Application username format in Okta](/deepdive/Okta-app-username-format.png "Set the Application username format in Okta")
+    - Click **Save**.
+1. Done!
+
+## Notes
+
+The following SAML attributes are supported:
+
+| Name      | Value          |
+| --------- | -------------- |
+| email     | user.userName     |

--- a/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/saml-migration.md
+++ b/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/saml-migration.md
@@ -109,6 +109,11 @@ To update your existing SAML configuration with Google:
 
 #### Okta
 
+Instructions differ depending on how you've set up your Cobalt SAML app in Okta. Click <i style="font-size:x-large; color: #0047AB" class="fas fa-chevron-right"></i> to view instructions.
+
+{{%expand "Non-gallery SAML app" %}}
+<br>
+
 To update your existing SAML configuration with Okta for a non-gallery SAML app:
 
 1. In Cobalt, go to **Settings** > **Identity & Access**. Under **Configure SAML**, select **Configure**.
@@ -127,7 +132,32 @@ To update your existing SAML configuration with Okta for a non-gallery SAML app:
     - **IdP SSO URL**: Enter the **Sign on URL** from Okta.
     - **IdP Certificate**: Enter the **Signing Certificate** from Okta.
     - Select **Save Configuration**.
+{{% /expand %}}
 
+{{%expand "Gallery SAML app for Cobalt" %}}
+<br>
+
+To update your existing SAML configuration with Okta for a [gallery SAML app for Cobalt](https://www.okta.com/integrations/cobalt/):
+
+1. In Cobalt, go to **Settings** > **Identity & Access**. Under **Configure SAML**, select **Configure**.
+    - Copy the organization's **slug** that appears after `=` in the ACS URL. You can also see the slug in **Settings** > **General**.<br><br>
+    ![Organization's slug in the ACS URL](/deepdive/slug-acs-url.png "Organization's slug in the ACS URL")
+1. In Okta, go to your gallery SAML app for Cobalt. Select the **Sign On** tab, then select **Edit**.
+    - Delete the **Default Relay State** value.<br><br>
+    ![Delete the Default Relay State in your gallery Cobalt SAML app in Okta](/deepdive/Cobalt-configuration-for-Okta-preintegrated-app-3.png "Delete the Default Relay State in your gallery Cobalt SAML app in Okta")
+    - Under **Metadata details**, select **More details**.
+        - Copy the **Sign on URL**.
+        - Download or copy the **Signing Certificate**.<br><br>
+    ![Update your SAML configuration in a gallery Cobalt SAML app in Okta](/deepdive/Cobalt-configuration-for-Okta-manual-app-2.png "Update your SAML configuration in a gallery Cobalt SAML app in Okta")
+    - Under **Advanced Sign-on Settings**, in the **Slug** field, enter your organization’s slug from Cobalt.<br><br>
+    ![Enter your organization's slug in a gallery Cobalt SAML app in Okta](/deepdive/Cobalt-configuration-for-Okta-preintegrated-app-1.png "Enter your organization's slug in a gallery Cobalt SAML app in Okta")
+    - Save the changes.<br><br>
+1. In Cobalt, go to **Settings** > **Identity & Access**. Under **Configure SAML**, select **Configure**.
+    - **IdP SSO URL**: Enter the **Sign on URL** from Okta.
+    - **IdP Certificate**: Enter the **Signing Certificate** from Okta.
+    - Select **Save Configuration**.<br><br>
+    ![Update your SAML configuration in a gallery Cobalt SAML app](/deepdive/Cobalt-configuration-for-Okta-preintegrated-app-2.png "Update your SAML configuration in a gallery Cobalt SAML app")
+{{% /expand %}}
 <br>
 
 If you want to set up a new application, follow this [instruction](/platform-deep-dive/organization/organization-settings/saml-sso/#okta).


### PR DESCRIPTION
This PR will reintroduce the product docs for SAML Okta Gallery App that we removed as part of the app.cobalt.io --> app.us.cobalt.io URL update. 