### PR TITLE
[FND-3210] Fix relay state docs for Azure AD SAML SSO

### DIFF
--- a/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/_index.md
+++ b/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/_index.md
@@ -108,7 +108,7 @@ To configure SAML SSO with Azure Active Directory (Azure AD):
          - For EU data center: `https://api.eu.cobalt.io/users/saml/metadata`
        - **Reply URL** (Assertion Consumer Service URL): **ACS URL** from Cobalt (unique value for each organization).<br>Copy the value in the Cobalt app in **Settings** > **Identity & Access** > **Configure SAML**.
        - **Sign on URL**: Leave this field blank.
-       - **Relay State**: Leave this field.
+       - **Relay State**: Leave this field blank.
        - **Logout URL**: Leave this field blank.
     - Under **User Attributes & Claims**, add custom attribute mappings to your SAML token attributes configuration.
        - **email**: `user.mail`


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| SAML SSO | [Azure AD](https://deploy-preview-431--cobalt-docs.netlify.app/platform-deep-dive/organization/organization-settings/saml-sso/#azure-ad) | Fixed docs for relay state in Azure AD section |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
