### PR TITLE
[SS-208] Retest SLA is days, not business days.

### DIFF
--- a/content/en/Platform Deep Dive/Pentests/Findings/remediate-findings.md
+++ b/content/en/Platform Deep Dive/Pentests/Findings/remediate-findings.md
@@ -39,7 +39,7 @@ For Agile and Comprehensive Pentests that Cobalt pentesters perform, you can sub
 - Until the end of the [free retesting](#free-retesting-duration) period; or
 - 10 days before your contract ends.
 
-Cobalt pentesters complete retesting within seven (7) business days after submission.
+Cobalt pentesters complete retesting within seven (7) days after submission.
 {{< /alert >}}
 
 ### Free Retesting Duration


### PR DESCRIPTION
## Changelog

### Added

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| remediate-findings.md | Link | Retest SLA is calendar days, not business days. |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[X] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
