### PR TITLE
[FND-3177] Recovery codes documentation - Fix

### DIFF
--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -45,7 +45,7 @@ If you lost access to your authenticator, ask your [Organization Owner](/platfor
 
 Once your Organization Owner has turned off 2FA, you get an email notification. You can now sign in without a second authentication factor.
 
-If you have a [recovery code](/platform-deep-dive/cobalt-account/account-recovery/#recovery-code)) enabled:
+If you have a [recovery code](/platform-deep-dive/cobalt-account/account-recovery/#recovery-code) enabled:
 
 1. Sign in as usual with your email and password.
 2. Under **Verify Your Identity**, select **Try another method**, then **Recovery code**.

--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -45,7 +45,7 @@ If you lost access to your authenticator, ask your [Organization Owner](/platfor
 
 Once your Organization Owner has turned off 2FA, you get an email notification. You can now sign in without a second authentication factor.
 
-If you have a [recovery code](#recovery-code) enabled:
+If you have a [recovery code](/platform-deep-dive/cobalt-account/account-recovery/#recovery-code)) enabled:
 
 1. Sign in as usual with your email and password.
 2. Under **Verify Your Identity**, select **Try another method**, then **Recovery code**.

--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -45,7 +45,7 @@ If you lost access to your authenticator, ask your [Organization Owner](/platfor
 
 Once your Organization Owner has turned off 2FA, you get an email notification. You can now sign in without a second authentication factor.
 
-If you have a [recovery code](/platform-deep-dive/cobalt-account/account-recovery/#recovery-code) enabled:
+If you have a [recovery code](/getting-started/glossary/#recovery-code) enabled:
 
 1. Sign in as usual with your email and password.
 2. Under **Verify Your Identity**, select **Try another method**, then **Recovery code**.

--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -66,7 +66,7 @@ To enable 2FA on your account:
 2. Under **Two-Factor Authentication (2FA)**, select **Manage**, and reauthenticate to your account.
 3. To add a new authenticator device, select **Set Up**.
 4. Follow the instructions on the screen to complete the process. Use an authenticator of your choice, such as [Authy](https://authy.com/) or [Google Authenticator](https://support.google.com/accounts/answer/1066447).
-5. After selecting **Continue**, you will see your [recovery code](platform-deep-dive/cobalt-account/account-recovery/#recovery-code). Save the code. After you close the overlay, you won’t see the code again.
+5. After selecting **Continue**, you will see your [recovery code](/platform-deep-dive/cobalt-account/account-recovery/#recovery-code). Save the code. After you close the overlay, you won’t see the code again.
 
 Now, each time you sign in to Cobalt, you must enter a one-time code from your authenticator app. If you have problems signing in with 2FA, see our [troubleshooting tips](/platform-deep-dive/cobalt-account/account-recovery/#problems-with-two-factor-authentication).
 

--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -66,7 +66,7 @@ To enable 2FA on your account:
 2. Under **Two-Factor Authentication (2FA)**, select **Manage**, and reauthenticate to your account.
 3. To add a new authenticator device, select **Set Up**.
 4. Follow the instructions on the screen to complete the process. Use an authenticator of your choice, such as [Authy](https://authy.com/) or [Google Authenticator](https://support.google.com/accounts/answer/1066447).
-5. After selecting **Continue**, you will see your recovery code. Save the code. After you close the overlay, you won’t see the code again.
+5. After selecting **Continue**, you will see your [recovery code](platform-deep-dive/cobalt-account/account-recovery/#recovery-code). Save the code. After you close the overlay, you won’t see the code again.
 
 Now, each time you sign in to Cobalt, you must enter a one-time code from your authenticator app. If you have problems signing in with 2FA, see our [troubleshooting tips](/platform-deep-dive/cobalt-account/account-recovery/#problems-with-two-factor-authentication).
 

--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -74,8 +74,6 @@ Now, each time you sign in to Cobalt, you must enter a one-time code from your a
 
 When you add a new 2FA device, it appears on the account security page<!--under **Current Devices**-->. Here, you can see the authenticator app that generates one-time codes required for authentication to your Cobalt account.
 
-- **Remove an app** if it's no longer valid or has been lost or stolen. Select **Delete**, and confirm your action.
-
 #### Reset Two-Factor Authentication
 
 We don't recommend turning off 2FA on your account. However, you may need to reset your 2FA methods when:

--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -66,7 +66,7 @@ To enable 2FA on your account:
 2. Under **Two-Factor Authentication (2FA)**, select **Manage**, and reauthenticate to your account.
 3. To add a new authenticator device, select **Set Up**.
 4. Follow the instructions on the screen to complete the process. Use an authenticator of your choice, such as [Authy](https://authy.com/) or [Google Authenticator](https://support.google.com/accounts/answer/1066447).
-5. After selecting **Continue**, you will see your [recovery code](/platform-deep-dive/cobalt-account/account-recovery/#recovery-code). Save the code. After you close the overlay, you won’t see the code again.
+5. After selecting **Continue**, you will see your [recovery code](/getting-started/glossary/#recovery-code). Save the code. After you close the overlay, you won’t see the code again.
 
 Now, each time you sign in to Cobalt, you must enter a one-time code from your authenticator app. If you have problems signing in with 2FA, see our [troubleshooting tips](/platform-deep-dive/cobalt-account/account-recovery/#problems-with-two-factor-authentication).
 

--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -66,7 +66,7 @@ To enable 2FA on your account:
 2. Under **Two-Factor Authentication (2FA)**, select **Manage**, and reauthenticate to your account.
 3. To add a new authenticator device, select **Set Up**.
 4. Follow the instructions on the screen to complete the process. Use an authenticator of your choice, such as [Authy](https://authy.com/) or [Google Authenticator](https://support.google.com/accounts/answer/1066447).
-5. After selecting Continue, you will see your recovery code. Save the code. After you close the overlay, you won’t see the code again.
+5. After selecting **Continue**, you will see your recovery code. Save the code. After you close the overlay, you won’t see the code again.
 
 Now, each time you sign in to Cobalt, you must enter a one-time code from your authenticator app. If you have problems signing in with 2FA, see our [troubleshooting tips](/platform-deep-dive/cobalt-account/account-recovery/#problems-with-two-factor-authentication).
 
@@ -74,7 +74,7 @@ Now, each time you sign in to Cobalt, you must enter a one-time code from your a
 
 When you add a new 2FA device, it appears on the account security page<!--under **Current Devices**-->. Here, you can see the authenticator app that generates one-time codes required for authentication to your Cobalt account.
 
-- **Remove an app ** if it's no longer valid or has been lost or stolen. Select **Delete**, and confirm your action.
+- **Remove an app** if it's no longer valid or has been lost or stolen. Select **Delete**, and confirm your action.
 
 #### Reset Two-Factor Authentication
 


### PR DESCRIPTION
## Changelog

### Added

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
