### PR TITLE
[FND-3307] Embed recovery code videos

### DIFF
--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -47,7 +47,7 @@ Once your Organization Owner has turned off 2FA, you get an email notification. 
 
 If you have a [recovery code](/getting-started/glossary/#recovery-code) enabled:
 
-<iframe width="600" height="293" src="https://www.loom.com/embed/e21fe27754c542dba799f4c016e0e7fc?sid=ca5f37b1-c1b3-497b-b29c-782c898190b1?hide_owner=true&hide_share=true&hideEmbedTopBar=true" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+<iframe width="600" height="291" src="https://www.loom.com/embed/eebe34fc674a4fe5917ac6b94a445997?sid=7a3aab21-0c0f-44c6-b43c-95f01e5ef5bb?hide_owner=true&hide_share=true&hideEmbedTopBar=true" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 1. Sign in as usual with your email and password.
 2. Under **Verify Your Identity**, select **Try another method**, then **Recovery code**.

--- a/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-recovery.md
@@ -47,6 +47,8 @@ Once your Organization Owner has turned off 2FA, you get an email notification. 
 
 If you have a [recovery code](/getting-started/glossary/#recovery-code) enabled:
 
+<iframe width="600" height="293" src="https://www.loom.com/embed/e21fe27754c542dba799f4c016e0e7fc?sid=ca5f37b1-c1b3-497b-b29c-782c898190b1?hide_owner=true&hide_share=true&hideEmbedTopBar=true" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+
 1. Sign in as usual with your email and password.
 2. Under **Verify Your Identity**, select **Try another method**, then **Recovery code**.
 3. Enter your saved recovery code. You will be prompted to save a new recovery code for future use before access to your account.

--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -84,6 +84,8 @@ You can remove your current 2FA device and add a new one for added security.
 
 To remove a 2FA device:
 
+<div style="position: relative; padding-bottom: 70.8649468892261%; height: 0;"><iframe src="https://www.loom.com/embed/779b1b5ca1754b5aa7f7d4247202c836?sid=b6b3b1a2-e8a7-428d-9d9b-88e0a9fbce22?hide_owner=true&hide_share=true&hideEmbedTopBar=true” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+
 1. Navigate to https://app.cobalt.io/settings/security/2fa.
 1. Under **Two-Factor Authentication (2FA)**, select **Manage**.
 1. Locate the desired device, and select the trash icon.

--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -84,7 +84,7 @@ You can remove your current 2FA device and add a new one for added security.
 
 To remove a 2FA device:
 
-<div style="position: relative; padding-bottom: 70.8649468892261%; height: 0;"><iframe src="https://www.loom.com/embed/779b1b5ca1754b5aa7f7d4247202c836?sid=b6b3b1a2-e8a7-428d-9d9b-88e0a9fbce22?hide_owner=true&hide_share=true&hideEmbedTopBar=true” frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+<iframe width="640" height="454" src="https://www.loom.com/embed/779b1b5ca1754b5aa7f7d4247202c836?sid=419a5bf0-1eed-4447-a215-73eb581321e8?hide_owner=true&hide_share=true&hideEmbedTopBar=true" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 1. Navigate to https://app.cobalt.io/settings/security/2fa.
 1. Under **Two-Factor Authentication (2FA)**, select **Manage**.

--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -84,7 +84,8 @@ You can remove your current 2FA device and add a new one for added security.
 
 To remove a 2FA device:
 
-<iframe width="640" height="454" src="https://www.loom.com/embed/779b1b5ca1754b5aa7f7d4247202c836?sid=419a5bf0-1eed-4447-a215-73eb581321e8?hide_owner=true&hide_share=true&hideEmbedTopBar=true" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+<iframe width="600" height="426" src="https://www.loom.com/embed/779b1b5ca1754b5aa7f7d4247202c836?sid=419a5bf0-1eed-4447-a215-73eb581321e8?hide_owner=true&hide_share=true&hideEmbedTopBar=true" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+
 
 1. Navigate to https://app.cobalt.io/settings/security/2fa.
 1. Under **Two-Factor Authentication (2FA)**, select **Manage**.

--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -62,6 +62,8 @@ If you're **signing in with your email and password**, you can enable two-factor
 
 To enable 2FA on your account:
 
+<iframe width="600" height="302" src="https://www.loom.com/embed/2c7043b983224c228c7012f95972e786?sid=5cdc7e81-7955-4468-a708-bafc59578f71?hide_owner=true&hide_share=true&hideEmbedTopBar=true" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+
 1. Navigate to https://app.cobalt.io/settings/security/2fa.
 2. Under **Two-Factor Authentication (2FA)**, select **Manage**, and reauthenticate to your account.
 3. To add a new authenticator device, select **Set Up**.

--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -62,7 +62,7 @@ If you're **signing in with your email and password**, you can enable two-factor
 
 To enable 2FA on your account:
 
-<iframe width="600" height="302" src="https://www.loom.com/embed/2c7043b983224c228c7012f95972e786?sid=5cdc7e81-7955-4468-a708-bafc59578f71?hide_owner=true&hide_share=true&hideEmbedTopBar=true" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+<iframe width="600" height="301" src="https://www.loom.com/embed/3b33b59038374e2fa09f6f3f0fb5a2fb?sid=4a203b01-bbdd-4957-b5a0-64ceeb37d002?hide_owner=true&hide_share=true&hideEmbedTopBar=true" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 1. Navigate to https://app.cobalt.io/settings/security/2fa.
 2. Under **Two-Factor Authentication (2FA)**, select **Manage**, and reauthenticate to your account.


### PR DESCRIPTION
## Changelog

### Added

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
