### PR TITLE
[FX-3987] Add seed paths and avoided urls docs

### DIFF
--- a/content/en/Platform Deep Dive/Scans/_index.md
+++ b/content/en/Platform Deep Dive/Scans/_index.md
@@ -35,7 +35,7 @@ We use the following IP Address to make requests to your target: **52.19.40.38**
 
 ![Add Target](/deepdive/scans/2_AddTarget.png "Add Target")<br>
 
-See more about how to configure a target in [targets]
+See more about how to configure a target in [configuring a target]
 
 
 ### Scan Scheduling
@@ -163,4 +163,4 @@ For support, please reach out to your CSM or email us at dast@cobalt.io.
 <!-- links -->
 
 [Report types]: #report-types
-[targets]: /platform-deep-dive/scans/targets
+[configuring a target]: /platform-deep-dive/scans/targets#configuring-a-target

--- a/content/en/Platform Deep Dive/Scans/_index.md
+++ b/content/en/Platform Deep Dive/Scans/_index.md
@@ -35,21 +35,8 @@ We use the following IP Address to make requests to your target: **52.19.40.38**
 
 ![Add Target](/deepdive/scans/2_AddTarget.png "Add Target")<br>
 
-### Authentication
+See more about how to configure a target in [targets]
 
-- To add authentication toggle on the “Authenticated Scan” option
-    - Follow the Steps to add authentication details
-      1. Login form URL
-      2. Add fields (You will likely have one field for username and one for password)
-          - Field Name
-          - Field Value
-    - **NOTE**: Currently, the DAST Scanner only supports login form authentication.
-      
-      3. (Optional) Add the Submit Button: if the submit button is outside of your `<form>` tag, or especially if your login inputs are not inside a `<form>` tag, then the `submit_button` must be defined so that the right button is clicked. For that, add a new field in the target authentication settings, with `submit_button` in the name, and the respective button CSS selector in the value (it must be a CSS selector) as, for example, `#login-form-container button[type="submit"]`.
- 
-    - **NOTE**: Currently, the DAST Scanner tool only supports login form authentication. Learn more about [target authentication](/platform-deep-dive/scans/target_auth).
-
-![Authenticated Scan](/deepdive/scans/3_AuthenticatedScan.png "Authenticated Scan")<br>
 
 ### Scan Scheduling
 
@@ -176,3 +163,4 @@ For support, please reach out to your CSM or email us at dast@cobalt.io.
 <!-- links -->
 
 [Report types]: #report-types
+[targets]: /platform-deep-dive/scans/targets

--- a/content/en/Platform Deep Dive/Scans/target_auth.md
+++ b/content/en/Platform Deep Dive/Scans/target_auth.md
@@ -16,7 +16,7 @@ When a scan is started and the target has a login configuration, the first thing
 
 To add authentication toggle on the “Authenticated Scan” option and then:
 
-1. Add the URL where the login form is
+1. Add the URL where the login form is located.
 2. Add fields (You will likely have one field for username and one for password)
     - Field Name
     - Field Value

--- a/content/en/Platform Deep Dive/Scans/target_auth.md
+++ b/content/en/Platform Deep Dive/Scans/target_auth.md
@@ -12,6 +12,23 @@ If your website has areas that require authentication, you may provide the DAST 
 
 When a scan is started and the target has a login configuration, the first thing the crawler does is log into the application (web target) to obtain a session. Upon successful login, it will start crawling the app. While the crawler is running, it constantly verifies whether the session is still valid. Currently, this check is performed automatically based on the login configuration, but soon we will have the option to configure how the loss of session can be detected.
 
+# Basic steps
+
+To add authentication toggle on the “Authenticated Scan” option and then:
+
+1. Add the URL where the login form is
+2. Add fields (You will likely have one field for username and one for password)
+    - Field Name
+    - Field Value
+
+3. (Optional) Add the Submit Button: if the submit button is outside of your `<form>` tag, or especially if your login
+inputs are not inside a `<form>` tag, then the `submit_button` must be defined so that the right button is clicked.
+For that, add a new field in the target authentication settings, with `submit_button` in the name, and the respective
+button CSS selector in the value (it must be a CSS selector) as, for example, `#login-form-container button[type="submit"]`.
+
+
+![Authenticated Scan](/deepdive/scans/3_AuthenticatedScan.png "Authenticated Scan")<br>
+
 
 # Using a Login Form
 
@@ -68,7 +85,7 @@ To address this, we offer the option to define the button that should be clicked
 - Field value: `<CSS selector of an element only visible when logged out>` (e.g., `form.login #username`) or
 - Field value: `["CSS selector 1", "CSS selector 2"]` (e.g., `["#form.login #username", "form.login #password"]`)
 
-### Wait for a loading login input/element 
+### Wait for a loading login input/element
 
 To wait for a login input/element when the target has some unusual behavior while loading the login page, or to click on a button to go to the login page without the need for a login sequence:
 

--- a/content/en/Platform Deep Dive/Scans/target_auth.md
+++ b/content/en/Platform Deep Dive/Scans/target_auth.md
@@ -14,7 +14,7 @@ When a scan is started and the target has a login configuration, the first thing
 
 # Basic steps
 
-To add authentication toggle on the “Authenticated Scan” option and then:
+To add authentication, toggle on the “Authenticated Scan” option and then:
 
 1. Add the URL where the login form is located.
 2. Add the fields required for login. You will likely have one field for username and one for password.

--- a/content/en/Platform Deep Dive/Scans/target_auth.md
+++ b/content/en/Platform Deep Dive/Scans/target_auth.md
@@ -21,12 +21,6 @@ To add authentication, toggle on the “Authenticated Scan” option and then:
     - Field Name
     - Field Value
 
-3. (Optional) Add the Submit Button: if the submit button is outside of your `<form>` tag, or especially if your login
-inputs are not inside a `<form>` tag, then the `submit_button` must be defined so that the right button is clicked.
-For that, add a new field in the target authentication settings, with `submit_button` in the name, and the respective
-button CSS selector in the value (it must be a CSS selector) as, for example, `#login-form-container button[type="submit"]`.
-
-
 ![Authenticated Scan](/deepdive/scans/3_AuthenticatedScan.png "Authenticated Scan")<br>
 
 

--- a/content/en/Platform Deep Dive/Scans/target_auth.md
+++ b/content/en/Platform Deep Dive/Scans/target_auth.md
@@ -17,7 +17,7 @@ When a scan is started and the target has a login configuration, the first thing
 To add authentication toggle on the “Authenticated Scan” option and then:
 
 1. Add the URL where the login form is located.
-2. Add fields (You will likely have one field for username and one for password)
+2. Add the fields required for login. You will likely have one field for username and one for password.
     - Field Name
     - Field Value
 

--- a/content/en/Platform Deep Dive/Scans/targets.md
+++ b/content/en/Platform Deep Dive/Scans/targets.md
@@ -52,7 +52,7 @@ For instance, with a target of `https://example.com`, the scan would cover `http
 
 A clear and well-defined DAST target ensures the scan focuses on the specific areas of an application most susceptible to external threats.
 
-## Configuring a target
+## Configuring a Target
 
 There are a few configuration options available when setting up targets.
 

--- a/content/en/Platform Deep Dive/Scans/targets.md
+++ b/content/en/Platform Deep Dive/Scans/targets.md
@@ -65,7 +65,7 @@ https://example.com/admin*
 https://api.example.com/api/users*
 https://example.com/account*
 ```
-- **Seed paths**: In a similar way, a scan starts usually from the target url. Sometimes, there are some pages that are not reachable from there. If you want to add some extra starting points for the scan, you can use seed paths. Note that only relative paths are allowed
+- **Seed Paths**: In a similar way, a scan starts usually from the target url. Sometimes, there are some pages that are not reachable from there. If you want to add some extra starting points for the scan, you can use seed paths. Note that only relative paths are allowed
 and the Avoided URLs take precedence. This is a valid example:
 
 ```

--- a/content/en/Platform Deep Dive/Scans/targets.md
+++ b/content/en/Platform Deep Dive/Scans/targets.md
@@ -73,4 +73,5 @@ posts/search?query=coablt
 ```
 
 <!-- links -->
-[Authentication]: /deepdive/scans/target_auth
+[Authentication]: /platform-deep-dive/scans/target_auth
+

--- a/content/en/Platform Deep Dive/Scans/targets.md
+++ b/content/en/Platform Deep Dive/Scans/targets.md
@@ -58,19 +58,19 @@ There are a few configuration options available when setting up targets.
 
 - **Authenticated targets**: You can see a detailed explanation in [Authentication]
 
-- **Avoided URLs**: Scans work by crawling and discovering new urls in your application. If you want to avoid scanning certain parts
-of the app or reducing the scope of the scan, you can add them to Avoided URLs. These are valid examples for avoided URLs:
+- **Avoided URLs**: Scans work by crawling and discovering new urls in your application. If you want to reduce the scope of the scan to
+avoid scanning certain parts of the app, you can add them to Avoided URLs. These are valid examples for avoided URLs:
 ```
 https://example.com/admin*
 https://api.example.com/api/users*
 https://example.com/account*
 ```
 - **Seed paths**: In a similar way, a scan starts usually from the target url. Sometimes, there are some pages that are not reachable from there. If you want to add some extra starting points for the scan, you can use seed paths. Note that only relative paths are allowed
-and the Avoided URLs take precedence. These are some valid examples:
+and the Avoided URLs take precedence. This is a valid example:
 
 ```
 posts/search?query=coablt
 ```
 
 <!-- links -->
-[Authentication]: /deepdive/scans/target_auth.md
+[Authentication]: /deepdive/scans/target_auth

--- a/content/en/Platform Deep Dive/Scans/targets.md
+++ b/content/en/Platform Deep Dive/Scans/targets.md
@@ -69,7 +69,7 @@ https://example.com/account*
 and the Avoided URLs take precedence. This is a valid example:
 
 ```
-posts/search?query=coablt
+posts/search?query=cobalt
 ```
 
 <!-- links -->

--- a/content/en/Platform Deep Dive/Scans/targets.md
+++ b/content/en/Platform Deep Dive/Scans/targets.md
@@ -14,7 +14,7 @@ A target defines the scope of the scan.
 
 ![Breakdown of a DAST Target URL](/deepdive/scans/Anatomy_DASTTarget.png "Breakdown of a DAST Target URL")
 
-A DAST target is the specific entry point (URL or endpoint) of a web application, website, API, or any component that accepts input from the outside world. It defines the scope, or boundaries, of the security scan conducted by a DAST tool, limiting the tool to analyzing only those pages, links, or forms within the target's domain. 
+A DAST target is the specific entry point (URL or endpoint) of a web application, website, API, or any component that accepts input from the outside world. It defines the scope, or boundaries, of the security scan conducted by a DAST tool, limiting the tool to analyzing only those pages, links, or forms within the target's domain.
 
 For instance, with a target of `https://example.com`, the scan would cover `https://example.com/app1` but not `https://app2.example.com`. Essentially, the scanner examines URLs beginning with "example.com."
 
@@ -42,7 +42,7 @@ For instance, with a target of `https://example.com`, the scan would cover `http
 
 ### What is NOT a DAST Target:
 
-- **Cobalt Assets:** Assets in Cobalt are non synonymous with targets. An asset is often an entire application, comprised of multiple internal and third-party systems, APIs, and other components. DAST tools don't analyze an entire codebase, but focus solely on parts that accept external input. Those components, which live within a unique URL (ie. `example.com`, `app.example.com` and `api.example.com`) would each constitute an individual target. 
+- **Cobalt Assets:** Assets in Cobalt are non synonymous with targets. An asset is often an entire application, comprised of multiple internal and third-party systems, APIs, and other components. DAST tools don't analyze an entire codebase, but focus solely on parts that accept external input. Those components, which live within a unique URL (ie. `example.com`, `app.example.com` and `api.example.com`) would each constitute an individual target.
 
 - **Servers or Networks:** While applications run on servers and interact with networks, DAST tools typically don't directly test these aspects.
 
@@ -51,3 +51,26 @@ For instance, with a target of `https://example.com`, the scan would cover `http
 - **Third Party Apps:** External applications that customers don't have approval to run scans or test on.
 
 A clear and well-defined DAST target ensures the scan focuses on the specific areas of an application most susceptible to external threats.
+
+## Configuring a target
+
+There are a few configuration options available when setting up targets.
+
+- **Authenticated targets**: You can see a detailed explanation in [Authentication]
+
+- **Avoided URLs**: Scans work by crawling and discovering new urls in your application. If you want to avoid scanning certain parts
+of the app or reducing the scope of the scan, you can add them to Avoided URLs. These are valid examples for avoided URLs:
+```
+https://example.com/admin*
+https://api.example.com/api/users*
+https://example.com/account*
+```
+- **Seed paths**: In a similar way, a scan starts usually from the target url. Sometimes, there are some pages that are not reachable from there. If you want to add some extra starting points for the scan, you can use seed paths. Note that only relative paths are allowed
+and the Avoided URLs take precedence. These are some valid examples:
+
+```
+posts/search?query=coablt
+```
+
+<!-- links -->
+[Authentication]: /deepdive/scans/target_auth.md

--- a/content/en/Platform Deep Dive/Scans/targets.md
+++ b/content/en/Platform Deep Dive/Scans/targets.md
@@ -56,7 +56,7 @@ A clear and well-defined DAST target ensures the scan focuses on the specific ar
 
 There are a few configuration options available when setting up targets.
 
-- **Authenticated targets**: You can see a detailed explanation in [Authentication]
+- **Authenticated targets**: You can see a detailed explanation in [Authentication].
 
 - **Avoided URLs**: Scans work by crawling and discovering new urls in your application. If you want to reduce the scope of the scan to
 avoid scanning certain parts of the app, you can add them to Avoided URLs. These are valid examples for avoided URLs:


### PR DESCRIPTION
## Changelog

### Added

Added seed paths and avoided urls
Added a configure target section. 
Removed "Authentication" from the main page and linked to the authentication section in the configure a target section. There is a bit of duplication, but since we'll add the advanced target UI soon, I'd rather do this bigger change later.

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
