### PR TITLE
[FX-4028] Embed Groups demo video into page

### DIFF
--- a/content/en/Platform Deep Dive/Collaboration/groups.md
+++ b/content/en/Platform Deep Dive/Collaboration/groups.md
@@ -10,7 +10,9 @@ description: >
 As an [Organization Owner](/platform-deep-dive/collaboration/user-roles/#organization-owner), you can manage access to your organization’s assets and their associated pentests and findings.
 {{% /pageinfo %}}
 
-Watch a demo video going over the Groups feature [here](https://videos.cobalt.io/watch/aLD1nkwYisFLrSXJLdBgAc).
+Watch a demo video going over the Groups feature:
+
+<iframe width="466" height="301" src="https://www.loom.com/embed/37841915aabe4bd3a96112ccc097668e?sid=c4a83555-1465-4d3c-b17e-4c0588f12f95" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 ## Create a Group
 


### PR DESCRIPTION
## Changelog

### Updated

Embedded Groups demo video via Loom into the Groups page

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
