### PR TITLE
[NO TICKET] Update allowlist/denylist terminology

### DIFF
--- a/content/en/BestPractices/prevent-ssti.md
+++ b/content/en/BestPractices/prevent-ssti.md
@@ -95,16 +95,16 @@ Improper use of templates may lead to both [Cross-Site Scripting (XSS)](https://
 {{config.__class__.__init__.__globals__['os'].popen('ls').read()}}
 ```
 
-### Bypassing Blacklists
+### Bypassing Denylists
 
-Attackers may circumvent the blacklists that you configured.
+Attackers may circumvent the denylists that you configured.
  
 ```python
 @app.route("/page")
-blacklist = ["__class__",”request[request.”]
+denylist = ["__class__",”request[request.”]
 def page():
     name = request.values.get('name')
-    for bad_string in blacklist:
+    for bad_string in denylist:
         if  bad_string in name:
             return "HACKING ATTEMPT {}".format(bad_string), 400
         else:
@@ -114,7 +114,7 @@ def page():
 
 #### Analysis
 
-A threat actor can bypass `__class__` and retrieve the value of a new GET parameter using `request.args.param`. Because we included `request.args.param` in the blacklist, we can use a native Jinja2 function `| attr().`
+A threat actor can bypass `__class__` and retrieve the value of a new GET parameter using `request.args.param`. Because we included `request.args.param` in the denylist, we can use a native Jinja2 function `| attr().`
 
 #### Impact
 

--- a/content/en/BestPractices/protect-against-xxe.md
+++ b/content/en/BestPractices/protect-against-xxe.md
@@ -279,7 +279,7 @@ To explore more XXE attack scenarios, refer to the OWASP [XML External Entity Pr
   - Use data formats such as JavaScript Object Notation (JSON) to prevent the serialization process that could prevent XXE attacks.
 - Use secure libraries.
   - Implement the latest patches in your XML libraries, and always use secure alternatives. Make sure to update the Simple Object Access Protocol (SOAP) to version 1.2 or later.
-- Implement whitelisting.
+- Implement allowlisting.
   - Sanitize and filter sensitive data within XML bodies to ensure that your application doesn't accept malicious payloads.
 - Use an XML Schema Definition (XSD) validator.
   - To validate the upload of XML and XSL files, use an XSD validator.

--- a/content/en/Getting started/pentest-preparation.md
+++ b/content/en/Getting started/pentest-preparation.md
@@ -38,7 +38,7 @@ The information you need to prepare before launching a pentest depends on your [
 - Technology stack
 - What's in and out of scope for the pentest (for example, APIs)
 - Product walk-through or documentation, if available
-- If the scope is not publicly available, whitelist Cobalt IPs
+- If the scope is not publicly available, allowlist Cobalt IPs
 - Special requirements for the pentest, if any
 - Optional:
   - User role matrix

--- a/content/en/Platform Deep Dive/Scans/best-practices.md
+++ b/content/en/Platform Deep Dive/Scans/best-practices.md
@@ -8,7 +8,7 @@ description: Tips and tricks to maximize the effectiveness of your DAST scans fr
 ## Reachability
 
 To ensure a successful scan, you should first verify the reachability of the target URL you provide. Several factors can impact the reachability of the target, including:
-- IP restrictions: Ensure that the scanner's IP is whitelisted in your firewall. You can find our IP on the [DAST scanner page].
+- IP restrictions: Ensure that the scanner's IP is allowlisted in your firewall. You can find our IP on the [DAST scanner page].
 - VPN restrictions: Make sure the scanner can access the target URL without a VPN.
 - Test the target URL in your browser from another network or location to confirm its accessibility.
 

--- a/layouts/shortcodes/network-manual-email.md
+++ b/layouts/shortcodes/network-manual-email.md
@@ -3,6 +3,6 @@ Cobalt pentesters check SMTP, POP3, and IMAP on the mail gateway for open relay 
 - Accept mail _only_ for the organization's domains
 - Not relay mail for other domains
 
-Attackers could exploit an open relay to flood the mail server with spam, which could lead to the domain being blacklisted.
+Attackers could exploit an open relay to flood the mail server with spam, which could lead to the domain being denylisted.
 
 Pentesters examine the mail server using a variety of methods, such as sending emails to non-existent domains.

--- a/layouts/shortcodes/network-vuln-scan-problems.md
+++ b/layouts/shortcodes/network-vuln-scan-problems.md
@@ -4,5 +4,5 @@ If a potential attacker achieves this goal, an organization could face:
   - Personnel records
   - Payment data
   - Other financial records
-- Attackers who use the mail gateway or website as the source of spam email. Other sites may blacklist the organization's domain and automatically reject legitimate email correspondence.
+- Attackers who use the mail gateway or website as the source of spam email. Other sites may denylist the organization's domain and automatically reject legitimate email correspondence.
 - Service disruptions, to the point when organization's resources become unavailable, either temporarily or permanently.


### PR DESCRIPTION
## Changelog

Updated terminology for allowlist/denylist across all documentation on the product docs site.

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
