### PR TITLE
Ss2 488 docs add tools used to scr product documentation

### DIFF
--- a/content/en/Cybersecurity Services/secure-code-review.md
+++ b/content/en/Cybersecurity Services/secure-code-review.md
@@ -40,6 +40,10 @@ Here are some steps that can be included in a secure code review:
 - Manually review business logic 
 - Provide recommendations on reasonable mitigations that could address discovered issues or suggested code changes or upgrade paths to fix findings (when applicable). 
 
+{{% alert title="Note" color="primary" %}}
+{{% various-tools %}}
+{{% /alert %}}
+
 #### Software Composition Analysis 
 
 During Software Composition Analysis (SCA), Cobalt analyzes open-source and third-party components for known vulnerabilities.
@@ -52,6 +56,17 @@ The six phases for SCA are:
 5. Risk Assessment
 6. Remediation Guidance  
 
+{{% alert title="Tools" color="primary" %}}
+Cobalt pentesters may use Software Composition Analysis tools such as:
+
+- Semgrep Pro
+- OWASP Dependency-Check
+- Snyk Open Source
+- Trivy
+- Sonatype
+- Jfrog Xray
+{{% /alert %}}
+
 #### Static Application Security Testing
 
 Cobalt leverages Static Application Security Testing (SAST) tools when performing secure code reviews which aids in the manual efforts when searching for patterns in large codebases. A benefit for using SAST tools is that it helps identify all instances of the vulnerability in the application. Some common findings found with a SAST tool are:
@@ -62,6 +77,18 @@ Cobalt leverages Static Application Security Testing (SAST) tools when performin
 - Insecure communications
 - Buffer overflows
 - Authorization flaws
+
+{{% alert title="Tools" color="primary" %}}
+Cobalt pentesters may use Static Application Security Testing tools such as:
+
+- Semgrep Pro
+- Bearer
+- Checkmarx
+- Fortify
+- Snyk
+- SonarQube
+- Veracode 
+{{% /alert %}}
 
 #### Manual Review of Business Logic
 

--- a/layouts/shortcodes/various-tools.md
+++ b/layouts/shortcodes/various-tools.md
@@ -1,1 +1,1 @@
-The tools that our pentesters use during each testing phase may vary from test to test.
+The tools that our pentesters use during each phase may vary from test to test.


### PR DESCRIPTION
## Changelog

### Added

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
