### PR TITLE
[FX-4787] Remove native integrations list from integrations page

### DIFF
--- a/content/en/Integrations/_index.md
+++ b/content/en/Integrations/_index.md
@@ -20,27 +20,6 @@ Streamline your pentesting and development workflows with Cobalt integrations.
 - Set up **Native** integrations in the Cobalt app to push Cobalt data to external apps. Here, you can also create [webhooks](/integrations/webhooks/) to get real-time pentest updates.
 - Enable **Partner** integrations in third-party apps. You need an [API token](/cobalt-api/create-personal-api-token/) to pull Cobalt data to external apps.
 
-| Integration | Type | Use |
-|:---|:---|:---|
-| <img src="/integrations/Jira.png" alt="Jira icon" title="Jira icon" width="35" style="padding-right: 5px"> [Jira](/integrations/jira/) | Native | <li>Push Cobalt findings as issues to Jira Cloud, Server, or Data Center</li><li>Synchronize Cobalt findings with Jira tickets bi-directionally</li>
-| <img src="/integrations/Github.png" alt="GitHub icon" title="GitHub icon" width="35" style="padding-right: 5px"> [GitHub](/integrations/github/) | Native | Push Cobalt findings as issues to GitHub (Cloud only)
-| <img src="/integrations/Webhooks.png" alt="Webhooks icon" title="Webhooks icon" width="35" style="padding-right: 5px"> [Webhooks](/integrations/webhooks/) | Native | Subscribe to real-time notifications for pentest events using API-based webhooks
-| <img src="/integrations/Slack.png" alt="Slack icon" title="Slack icon" width="35" style="padding-right: 5px"> [Slack](/integrations/slack/) | Native | Subscribe to updates directly in Slack
-| <img src="/integrations/AzureDevOps.png" alt="Azure DevOps icon" title="Azure DevOps icon" width="35" style="padding-right: 5px"> [Azure DevOps](/integrations/azure-devops) | Native | {{< beta-label >}} Push findings as work items to Azure DevOps Board
-| <img src="/integrations/Bitbucket.png" alt="Bitbucket icon" title="Bitbucket icon" width="35" style="padding-right: 5px"> [Bitbucket](/integrations/beta/) | Native | {{< coming-soon >}} Push findings as issues to Bitbucket
-| <img src="/integrations/ServiceNow.png" alt="ServiceNow icon" title="ServiceNow icon" width="35" style="padding-right: 5px"> [ServiceNow](/integrations/beta/) | Native | {{< coming-soon >}} Push findings as incidents to ServiceNow
-| <img src="/integrations/Zendesk.svg" alt="ServiceNow icon" title="Zendesk icon" width="35" style="padding-right: 5px"> [Zendesk](/integrations/beta/) | Native | {{< coming-soon >}} Push findings as tickets to Zendesk
-| <img src="/integrations/Trello.svg" alt="Trello icon" title="Trello icon" width="35" style="padding-right: 5px"> [Trello](/integrations/beta/) | Native | {{< coming-soon >}} Push findings as cards to Trello
-| <img src="/integrations/PivotalTracker.svg" alt="Pivotal Tracker icon" title="Pivotal Tracker icon" width="35" style="padding-right: 5px"> [Pivotal Tracker](/integrations/beta/) | Native | {{< coming-soon >}} Push findings as bugs to Pivotal Tracker
-| <img src="/integrations/PagerDuty.svg" alt="PagerDuty icon" title="PagerDuty icon" width="35" style="padding-right: 5px"> [PagerDuty](/integrations/beta/) | Native | {{< coming-soon >}} Push findings as incidents to PagerDuty
-| <img src="/integrations/Asana.svg" alt="Asana icon" title="Asana icon" width="35" style="padding-right: 5px"> [Asana](/integrations/beta/) | Native | {{< coming-soon >}} Push findings as tasks to Asana
-| <img src="/integrations/Jupiterone.png" alt="JupiterOne icon" title="JupiterOne icon" width="35" style="padding-right: 5px"> [JupiterOne](https://community.askj1.com/kb/articles/994-cobalt-integration-with-jupiterone) | Partner | Analyze pentest data with JupiterOne tools
-| <img src="/integrations/OneTrust.png" alt="OneTrust icon" title="OneTrust icon" width="35" style="padding-right: 5px"> [OneTrust](https://www.onetrust.com/products/certification-automation/) | Partner | Pull Cobalt pentest information into the OneTrust GRC & Security Assurance Cloud platform (previously Tugboat Logic)
-| <img src="/integrations/Defectdojo.png" alt="DefectDojo icon" title="DefectDojo icon" width="35" style="padding-right: 5px"> [DefectDojo](/integrations/defectdojo/) | Partner | Import your Cobalt pentest findings into DefectoDojo with Cobalt API
-| <img src="/integrations/Kennasecurity.png" alt="Kenna Security icon" title="Kenna Security icon" width="35" style="padding-right: 5px"> [Kenna Security](/integrations/kenna-security/) | Partner | Import Cobalt pentest findings
-| <img src="/integrations/PlexTrac.png" alt="PlexTrac icon" title="PlexTrac icon" width="35" style="padding-right: 5px"> [PlexTrac](https://docs.plextrac.com/plextrac-documentation/product-documentation/account-management/account-admin/tools-and-integrations/integrations/cobalt) | Partner | Import Cobalt findings into a PlexTrac report
-| <img src="/integrations/anecdotes.png" alt="anecdotes icon" title="anecdotes icon" width="35" style="padding-right: 5px"> [anecdotes](https://www.anecdotes.ai/plugins/security) | Partner | Integrate Cobalt findings into the anecdotes.ai compliance operating system
-
 ## Request an Integration
 
 Request to enable an integration for your next pentest to streamline your remediation workflows. Customize the configuration to suit your needs, and start pushing Cobalt findings to your preferred task management software:


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Integrations | https://deploy-preview-541--cobalt-docs.netlify.app/integrations/ | Remove native integrations list |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
