### PR TITLE
[FX-4114] Remove integration builder open beta warnings

### DIFF
--- a/content/en/Integrations/IntegrationBuilder/_index.md
+++ b/content/en/Integrations/IntegrationBuilder/_index.md
@@ -4,10 +4,6 @@ linkTitle: "Integration Builder"
 weight: 10
 ---
 
-{{% pageinfo %}}
-The Integration Builder is currently in Open Beta.
-{{% /pageinfo %}}
-
 ## Overview
 
 The Cobalt Integration Builder is a no-code automation platform which enables customers to create and manage custom

--- a/content/en/Platform Deep Dive/Scans/integrations.md
+++ b/content/en/Platform Deep Dive/Scans/integrations.md
@@ -5,10 +5,6 @@ weight: 50
 description: Push DAST findings to your ticketing system!
 ---
 
-{{% pageinfo %}}
-The DAST ticketing integration is currently in Open Beta.
-{{% /pageinfo %}}
-
 ## Overview
 
 The DAST ticketing integration allows you to push your DAST findings to your ticketing system as soon as vulnerabilities are detected.


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |
| integration builder | https://deploy-preview-547--cobalt-docs.netlify.app/integrations/integrationbuilder/ ||
| dast integrations | https://deploy-preview-547--cobalt-docs.netlify.app/platform-deep-dive/scans/integrations/ ||

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
