### PR TITLE
[FX-4406] Update hugo & docsy theme

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,7 +16,7 @@ defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["taxonomy"]
 
 # Highlighting config
 pygmentsCodeFences = true
@@ -30,6 +30,7 @@ pygmentsStyle = "tango"
 # Configure how URLs look like per section.
 # [permalinks]
 # blog = "/:section/:year/:month/:day/:slug/"
+# uglyURLs = true
 
 ## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
 [blackfriday]
@@ -54,13 +55,14 @@ id = "G-DNN2LHSZ75"
 [languages]
 [languages.en]
 title = "  Product Docs"
-description = "Documentation for Penetration testing as a Service"
 languageName ="English"
 # Weight used for sorting.
 weight = 1
+enableGitInfo = true
+[languages.en.params]
+description = "Documentation for Penetration testing as a Service"
 time_format_default = "January.01.2006"
 time_format_blog = "02.01.2006"
-enableGitInfo = true
 
 
 [markup]

--- a/config.toml
+++ b/config.toml
@@ -28,9 +28,8 @@ pygmentsUseClassic = false
 pygmentsStyle = "tango"
 
 # Configure how URLs look like per section.
-[permalinks]
+# [permalinks]
 # blog = "/:section/:year/:month/:day/:slug/"
-uglyURLs = true
 
 ## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
 [blackfriday]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,9 @@
 [build]
 publish = "public"
-command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"   
-  
+command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo"
+
 [build.environment]
-HUGO_VERSION = "0.109.0"
+HUGO_VERSION = "0.135.0"
 HUGO_ENV = "production"
 
 [[redirects]]


### PR DESCRIPTION
## Changelog

Had to update hugo to use the latest version of the docsy theme, which should contain styling fixes for the sidebar navigation.

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
