### PR TITLE
Add missing link to IB docs

### DIFF
--- a/content/en/Integrations/IntegrationBuilder/_index.md
+++ b/content/en/Integrations/IntegrationBuilder/_index.md
@@ -42,7 +42,7 @@ The Integration Builder provides a library of connectors for common business and
 ### Connection
 
 Integration Builder connects to apps to build recipes. Once authenticated, each the triggers and actions provided
-by that app become available to use across recipes. [See authentication best practices](/integrationbuilder/how-to-guides/#authentication-best-practices).
+by that app become available to use across recipes. [See authentication best practices](/integrations/integrationbuilder/how-to-guides/#authentication-best-practices).
 
 <iframe src="https://play.vidyard.com/a22pBZVWCwGaWvs8VQZXEC" width="640" height="360" frameborder="0" allowfullscreen></iframe>
 

--- a/content/en/Integrations/IntegrationBuilder/_index.md
+++ b/content/en/Integrations/IntegrationBuilder/_index.md
@@ -42,7 +42,7 @@ The Integration Builder provides a library of connectors for common business and
 ### Connection
 
 Integration Builder connects to apps to build recipes. Once authenticated, each the triggers and actions provided
-by that app become available to use across recipes. See authentication best practices.
+by that app become available to use across recipes. [See authentication best practices](/integrationbuilder/how-to-guides/#authentication-best-practices).
 
 <iframe src="https://play.vidyard.com/a22pBZVWCwGaWvs8VQZXEC" width="640" height="360" frameborder="0" allowfullscreen></iframe>
 


### PR DESCRIPTION
## Changelog

### Updated

- Link 'See authentication best practices' to https://docs.cobalt.io/integrations/integrationbuilder/how-to-guides/#authentication-best-practices that was missing from [here](https://docs.cobalt.io/integrations/integrationbuilder/#connection)

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
