### PR TITLE
[FX-4864] add deprecation warning to native GitHub integration

### DIFF
--- a/content/en/Integrations/github.md
+++ b/content/en/Integrations/github.md
@@ -9,7 +9,7 @@ description: >
 {{% pageinfo color="warning" %}}
 **Upgrade your GitHub integration**
 
-Our legacy GitHub integration will be deprecated on **January 1, 2025**. Migrate to our Integration Builder for more features and flexibility. [Learn more](https://docs.cobalt.io/integrations/integrationbuilder/how-to-guides/github/).
+Our legacy GitHub integration will be deprecated on **January 1, 2025**. Migrate to our Integration Builder for more features and flexibility. [Learn more](/integrations/integrationbuilder/how-to-guides/github/).
 {{% /pageinfo %}}
 
 {{% pageinfo %}}

--- a/content/en/Integrations/github.md
+++ b/content/en/Integrations/github.md
@@ -6,10 +6,16 @@ description: >
   Push Cobalt findings as issues to GitHub.
 ---
 
-{{% pageinfo %}}
-Learn how to set up an integration between Cobalt and GitHub (Cloud only). The availability of this feature depends on your [PtaaS tier](/platform-deep-dive/credits/ptaas-tiers/). 
+{{% pageinfo color="warning" }}
+**Upgrade your GitHub integration**
 
-<span style="background-color: #ECE6FA; padding: 2px;">To sync DAST & Engagement findings, use the [Integration Builder](/integrations/integrationbuilder/).</span> 
+Our legacy GitHub integration will be deprecated on **January 1, 2025**. Migrate to our Integration Builder for more features and flexibility. [Learn more](https://docs.cobalt.io/integrations/integrationbuilder/how-to-guides/github/).
+{{% /pageinfo %}}
+
+{{% pageinfo %}}
+Learn how to set up an integration between Cobalt and GitHub (Cloud only). The availability of this feature depends on your [PtaaS tier](/platform-deep-dive/credits/ptaas-tiers/).
+
+<span style="background-color: #ECE6FA; padding: 2px;">To sync DAST & Engagement findings, use the [Integration Builder](/integrations/integrationbuilder/).</span>
 {{% /pageinfo %}}
 
 ## Integration Overview
@@ -34,7 +40,7 @@ As an [Organization Owner](/platform-deep-dive/collaboration/user-roles/#organiz
 1. In Cobalt, navigate to **Pentests**, and select the desired pentest.
 1. Go to the **Integrations** tab.
 1. Follow the instructions in the UI under **GitHub**.<br><br>
-  ![Configure the integration between Cobalt and GitHub](/integrations/configure-GitHub-integration.png "Configure the integration between Cobalt and GitHub")
+   ![Configure the integration between Cobalt and GitHub](/integrations/configure-GitHub-integration.png "Configure the integration between Cobalt and GitHub")
 
 ## Push Findings to GitHub
 
@@ -48,7 +54,7 @@ To push a finding to GitHub:
 
 1. On the pentest page, go to the **Findings** tab, and select the desired finding.
 1. Select **External Issue Tracking**, then select **Create issue on GitHub**.<br><br>
-  ![Push a Cobalt finding to GitHub](/integrations/push-finding-to-GitHub.png "Push a Cobalt finding to GitHub")
+   ![Push a Cobalt finding to GitHub](/integrations/push-finding-to-GitHub.png "Push a Cobalt finding to GitHub")
 
 A new issue is created in your GitHub repository, and the issue number appears under **External Issue Tracking** in Cobalt. Click the link to navigate to the issue.
 

--- a/content/en/Integrations/github.md
+++ b/content/en/Integrations/github.md
@@ -6,11 +6,13 @@ description: >
   Push Cobalt findings as issues to GitHub.
 ---
 
-{{% pageinfo color="warning" }}
+{{% pageinfo color="warning" %}}
 **Upgrade your GitHub integration**
 
 Our legacy GitHub integration will be deprecated on **January 1, 2025**. Migrate to our Integration Builder for more features and flexibility. [Learn more](https://docs.cobalt.io/integrations/integrationbuilder/how-to-guides/github/).
+{{% /pageinfo %}}
 
+{{% pageinfo %}}
 Learn how to set up an integration between Cobalt and GitHub (Cloud only). The availability of this feature depends on your [PtaaS tier](/platform-deep-dive/credits/ptaas-tiers/).
 
 <span style="background-color: #ECE6FA; padding: 2px;">To sync DAST & Engagement findings, use the [Integration Builder](/integrations/integrationbuilder/).</span>

--- a/content/en/Integrations/github.md
+++ b/content/en/Integrations/github.md
@@ -10,9 +10,7 @@ description: >
 **Upgrade your GitHub integration**
 
 Our legacy GitHub integration will be deprecated on **January 1, 2025**. Migrate to our Integration Builder for more features and flexibility. [Learn more](https://docs.cobalt.io/integrations/integrationbuilder/how-to-guides/github/).
-{{% /pageinfo %}}
 
-{{% pageinfo %}}
 Learn how to set up an integration between Cobalt and GitHub (Cloud only). The availability of this feature depends on your [PtaaS tier](/platform-deep-dive/credits/ptaas-tiers/).
 
 <span style="background-color: #ECE6FA; padding: 2px;">To sync DAST & Engagement findings, use the [Integration Builder](/integrations/integrationbuilder/).</span>


### PR DESCRIPTION
## Changelog

Document the upcoming deprecation of the legacy GitHub integration. Prefer the Integration Builder over the native GitHub integration feature.

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Integrate GitHub with Cobalt | [Link](https://deploy-preview-560--cobalt-docs.netlify.app/integrations/github/) | Add a warning banner about the upcoming deprecation of the native GitHub integration feature. |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[x] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
