### PR TITLE
[NO-TICKET] Add note about IdP Domains and Enforce SAML fields

### DIFF
--- a/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/_index.md
+++ b/content/en/Platform Deep Dive/Organization/Organization Settings/SAML SSO/_index.md
@@ -84,6 +84,8 @@ SP-initiated SSO once your SAML configuration is set up:
   - Users with matching email addresses will be automatically redirected from
   our sign in form to your IdP to complete the authentication flow
   - This will have the same effect as enabling **Enforce SAML**
+  - **Note**: It is recommended to leave this field blank until after you have
+  tested your SAML connection and confirmed it's working.
 
 ## Enforce SAML SSO
 
@@ -98,6 +100,9 @@ To enforce SAML SSO for your organization:
 1. Under **SAML Single Sign-on (SSO)**, turn on the **Enforce SAML** toggle, and confirm your action.<br><br>
     ![Manage SAML enforcement for your organization](/deepdive/SAML-enforcement.png "Manage SAML enforcement for your organization")
 1. Notify users that now they must sign in through the selected identity provider. We don't send any notifications, so make sure that SAML enforcement doesn't disrupt your workflows.
+
+**Note**: It is recommended to leave this turned off until after you have tested
+your SAML connection and confirmed it's working.
 
 ## Configuration Instructions for Specific Identity Providers
 


### PR DESCRIPTION
## Changelog

The note advises to leave the domains field blank and enfore SAML turned off until after the connection has been tested and confirmed working.

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
