### PR TITLE
[FX-4976] Create guide for mapping Cobalt finding severity to Jira issue priority

### DIFF
--- a/content/en/Integrations/IntegrationBuilder/How to Guides/map-cobalt-pentest-finding-severity-to-jira-issue-priority.md
+++ b/content/en/Integrations/IntegrationBuilder/How to Guides/map-cobalt-pentest-finding-severity-to-jira-issue-priority.md
@@ -1,0 +1,14 @@
+---
+title: "Map Cobalt Pentest Finding Severity to Jira Issue Priority"
+linkTitle: "Map Cobalt Pentest Finding Severity to Jira Issue Priority"
+weight: 70
+---
+
+{{% pageinfo %}}
+
+This guide is designed to help [**Integration Builder**](/integrations/integrationbuilder/) users map the severity of pentest findings in Cobalt to the priority of new Jira issues.
+Please follow the [Create Jira tickets for Findings guide](./jira-cloud-migration) before proceeding with this guide.
+
+{{% /pageinfo %}}
+
+# Hello


### PR DESCRIPTION
## Changelog

### Added

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
