### PR TITLE
Chore/docs 500 release notes cleaning

### DIFF
--- a/content/en/Product Updates/release-notes-april-2024.md
+++ b/content/en/Product Updates/release-notes-april-2024.md
@@ -9,10 +9,8 @@ description: >-
 Explore What's New from Cobalt This Month
 {{% /pageinfo %}}
 
-### April 2024
 
-
-#### DAST Transition from Beta to General Availability
+## DAST Transition from Beta to General Availability
 
 We are excited to announce that our DAST scanner is now officially out of beta and available for General Availability to all Cobalt customers. With this release, all customers can now leverage our new DAST scanner feature, allowing them to create an unlimited number of scans for one target. Please note that additional targets can be purchased as needed to expand your scanning capabilities.
 
@@ -20,7 +18,7 @@ We are excited to announce that our DAST scanner is now officially out of beta a
 
 ---
 
-#### Cobalt Engagements: Introducing Digital Risk Assessments
+## Cobalt Engagements: Introducing Digital Risk Assessments
 
 We are thrilled to introduce Cobalt Engagements, a new platform feature that streamlines the process of conducting Digital Risk Assessments (DRA) and empowers customers to take control of their offensive security testing like never before.
 

--- a/content/en/Product Updates/release-notes-august-2024.md
+++ b/content/en/Product Updates/release-notes-august-2024.md
@@ -9,10 +9,8 @@ description: >-
 Explore What's New from Cobalt This Month
 {{% /pageinfo %}}
 
-### August 2024
 
-
-#### DAST Scan Controls & Progress Tracker
+## DAST Scan Controls & Progress Tracker
 
 We recently added scan controls to the Cobalt platform that enable customers to have better visibility into the duration and progress of their security scans. With these new controls, customers are able to pause, cancel, and resume a scan as needed. The controls are available on both the target and scan pages, accurately reflecting the current status of the scan.
 
@@ -29,7 +27,7 @@ View more scan controls available [here](https://docs.cobalt.io/platform-deep-di
 
 ---
 
-#### Targets as Structured Data
+## Targets as Structured Data
 
 The problem we identified was that targets were used in different parts of the application, such as in Attack Surface, DAST, Pentests, and Findings, without a structured connection between them. For instance, there was no clear association between a finding and the targets in scope for a pentest, leading to missed opportunities in capturing these associations.
 
@@ -39,7 +37,7 @@ To address this issue, we have introduced a new field called "Associated Targets
 
 ---
 
-#### Enhanced SAML Configuration Page in Org Settings
+## Enhanced SAML Configuration Page in Org Settings
 
 Customers utilizing Service Provider initiated SAML SSO can now seamlessly access this feature directly within the platform. After configuring SAML settings, organizations will now display a Cobalt Sign In URL. 
 
@@ -49,7 +47,7 @@ This URL simplifies the user experience by automatically redirecting users to th
 
 ---
 
-#### Improved Findings Order on the Pentest Report for Enhanced Clarity
+## Improved Findings Order on the Pentest Report for Enhanced Clarity
 
 Based on customer feedback, we have enhanced the ordering of findings to prioritize clarity and actionable insights.
 
@@ -61,7 +59,7 @@ This change applies to both the detailed findings section and the post-test reme
 
 ---
 
-#### Customer Credential Deletion Workflow
+## Customer Credential Deletion Workflow
 
 In the past, there was no effortless way to ensure that customers had appropriately managed their credentials after testing, potentially leaving sensitive data vulnerable. 
 

--- a/content/en/Product Updates/release-notes-january-2024.md
+++ b/content/en/Product Updates/release-notes-january-2024.md
@@ -9,10 +9,8 @@ description: >-
 Explore What's New from Cobalt This Month
 {{% /pageinfo %}}
 
-### January 2024
 
-
-#### Enhancements to Improve Transparency and Accountability in Carry Over Finding Process
+## Enhancements to Improve Transparency and Accountability in Carry Over Finding Process
 
 To address issues with findings not being carried over from previous pentests, we have implemented the following improvements:
 

--- a/content/en/Product Updates/release-notes-july-2024.md
+++ b/content/en/Product Updates/release-notes-july-2024.md
@@ -9,10 +9,8 @@ description: >-
 Explore What's New from Cobalt This Month
 {{% /pageinfo %}}
 
-### July 2024
 
-
-#### Attack Surface Updates
+## Attack Surface Updates
 
 In response to customer feedback and to better align with the comprehensive capabilities of the feature, we are excited to announce that 'Domains' has now been revamped as 'Attack Surface.' This new name reflects the broader scope and enhanced functionality that this feature offers to our users.
 
@@ -25,7 +23,7 @@ With intuitive charts and visual aids, customers can now gain a consolidated ove
 
 ---
 
-#### Ticketing Integrations Released for DAST Scans
+## Ticketing Integrations Released for DAST Scans
 
 Customers have expressed a strong desire to seamlessly integrate their DAST findings directly into their ticketing systems, a highly requested feature for DAST. In response to this feedback, we have enhanced our public API and Integration Builder to empower customers to:
 
@@ -35,13 +33,13 @@ Customers have expressed a strong desire to seamlessly integrate their DAST find
 
 With these improvements, customers will now receive real-time notifications when a DAST finding is detected or resolved. Additionally, we have introduced recipe templates in the Integration Builder Library, allowing customers to effortlessly push their DAST findings to popular platforms such as Jira Cloud, GitHub Issues, and Azure DevOps Boards.
 
-##### Steps to Integrate with Ticketing Systems
+#### Steps to Integrate with Ticketing Systems
 
 <iframe src="https://play.vidyard.com/kVCJ1gQ6ywr1t2G3K7Z46m" width="640" height="360" frameborder="0" allowfullscreen></iframe>
 
 ---
 
-#### DAST Release: Extra Hosts
+## DAST Release: Extra Hosts
 
 By introducing the “Extra Hosts” section to the target’s “Advanced Settings” page, customers now have the ability to include APIs residing on different hostnames as extra hosts. This enhancement ensures that the API will undergo scanning as part of the web target. The significance of this feature lies in providing customers with a more comprehensive view of their application's security. By scanning the API along with the web target, customers can identify and address vulnerabilities that may have gone undetected through isolated web target scans. 
 
@@ -51,7 +49,7 @@ This integrated approach enhances security measures and empowers customers to pr
 
 ---
 
-#### Email Notifications for DAST Scans
+## Email Notifications for DAST Scans
 
 We have implemented email notifications for the following key actions: successful scan completion, scan failure, target creation, and target deletion. These notifications will be sent to all organization owners and the Customer Success Manager (CSM). 
 
@@ -61,7 +59,7 @@ This enhancement ensures that important stakeholders are promptly informed about
 
 ---
 
-#### Secure Code Reviews
+## Secure Code Reviews
 
 We are pleased to announce that Secure Code Reviews are now available on the Cobalt platform! This comprehensive offering includes several key features, which are outlined below:
 

--- a/content/en/Product Updates/release-notes-june-2024.md
+++ b/content/en/Product Updates/release-notes-june-2024.md
@@ -9,10 +9,8 @@ description: >-
 Explore What's New from Cobalt This Month
 {{% /pageinfo %}}
 
-### June 2024
 
-
-#### Recurring Scheduled Scans
+## Recurring Scheduled Scans
 
 As part of our commitment to continually improve our platform, we are thrilled to announce the introduction of recurring scheduled scans to Cobalt DAST Scanner. This highly-requested feature makes it easier than ever to set up and run automatic scans on a recurring basis.
 
@@ -35,7 +33,7 @@ As part of our commitment to continually improve our platform, we are thrilled t
 
 ---
 
-#### API Scanning
+## API Scanning
 
 We are excited to introduce an advanced feature for users configuring a DAST target: the ability to select API with OpenAPI specifications and provide an OpenAPI/Swagger schema. This schema acts as a comprehensive map for the scanner, enabling it to effectively navigate and test all endpoints and functions of the API, ensuring thorough and accurate security testing.
 

--- a/content/en/Product Updates/release-notes-march-2024.md
+++ b/content/en/Product Updates/release-notes-march-2024.md
@@ -9,10 +9,8 @@ description: >-
 Explore What's New from Cobalt This Month
 {{% /pageinfo %}}
 
-### March 2024
 
-
-#### Services Platform Page is Renamed to Catalog
+## Services Platform Page is Renamed to Catalog
 
 To prepare for the impending launch of Engagements in April 2024, we have renamed the 'Services' page to 'Catalog'. The Catalog will serve as a centralized location housing our complete range of offensive security services. From this hub, customers will have the ability to create or request new offerings. Our aim is to make all of our services easy to access from one location, as our offerings continue to expand.
 
@@ -21,7 +19,7 @@ To prepare for the impending launch of Engagements in April 2024, we have rename
 
 ---
 
-#### New Chart in Insights
+## New Chart in Insights
 
 Cobalt now offers a clear and simple overview of how customers manage their open findings over time with our new Severity Trend chart. This chart has been seamlessly integrated into our new Home page as well as Insights, ensuring that our customers have access to valuable insights and actionable data to support their offensive security program.
 
@@ -29,7 +27,7 @@ Cobalt now offers a clear and simple overview of how customers manage their open
 
 ---
 
-#### New Home Page Launches
+## New Home Page Launches
 
 We are excited to announce the launch of our new 'Home' page on the Cobalt platform. This centralized dashboard will serve as the welcome screen for our customers when they log in, providing them with a single-pane view of their testing activity. 
 

--- a/content/en/Product Updates/release-notes-may-2024.md
+++ b/content/en/Product Updates/release-notes-may-2024.md
@@ -9,10 +9,8 @@ description: >-
 Explore What's New from Cobalt This Month
 {{% /pageinfo %}}
 
-### May 2024
 
-
-#### New Sequence Recorder for DAST scanning
+## New Sequence Recorder for DAST scanning
 
 We are thrilled to introduce Cobalt’s Sequence Recorder, a powerful browser plugin designed to enhance the DAST scanning experience. This innovative tool records your browser actions, providing invaluable assistance in setting up an authenticated target. The recorded actions are subsequently utilized by the scans to authenticate to the target, offering a seamless and efficient process.
 
@@ -22,7 +20,7 @@ With this cutting-edge feature, we can now address a wider range of use cases fo
 
 ---
 
-#### Introducing the Age by Severity Chart
+## Introducing the Age by Severity Chart
 
 We are excited to unveil a significant update on our Home page and Insights page - the introduction of the ‘Age by Severity’ chart, which replaces the previous ‘Time to Fix’ chart. This new feature provides a fresh perspective by focusing on the age of Open Findings, urging customers to take proactive actions towards addressing security issues.
 

--- a/content/en/Product Updates/release-notes-october-2024.md
+++ b/content/en/Product Updates/release-notes-october-2024.md
@@ -10,9 +10,9 @@ Explore What's New from Cobalt This Month
 {{% /pageinfo %}}
 
 
-#### DAST Improvements
+## DAST Improvements
 
-##### Expanded DAST Public API Capabilities
+### Expanded DAST Public API Capabilities
 
 Despite existing read-only endpoints in our public API, customers lacked the functionality to sync Cobalt DAST data with external DevSecOps tools such as ticketing, reporting, and Ci/CD platforms.
 
@@ -24,7 +24,7 @@ We’ve now enhanced our public API to enable users to:
 - Modify DAST finding states
 
 ---
-##### Scan Profiles
+### Scan Profiles
 
 We've implemented the option for users to select their preferred scan profile to customize scan behavior according to their specific requirements. Users can choose from a selection of 8 different profiles for immediate and scheduled scans, with more to be added if needed. Notably, scan profiles are target-specific, with different profiles available for API and web targets.
 

--- a/content/en/Product Updates/release-notes-october-2024.md
+++ b/content/en/Product Updates/release-notes-october-2024.md
@@ -23,7 +23,7 @@ We’ve now enhanced our public API to enable users to:
 - Retest DAST findings
 - Modify DAST finding states
 
----
+
 ### Scan Profiles
 
 We've implemented the option for users to select their preferred scan profile to customize scan behavior according to their specific requirements. Users can choose from a selection of 8 different profiles for immediate and scheduled scans, with more to be added if needed. Notably, scan profiles are target-specific, with different profiles available for API and web targets.

--- a/content/en/Product Updates/release-notes-october-2024.md
+++ b/content/en/Product Updates/release-notes-october-2024.md
@@ -28,7 +28,9 @@ We’ve now enhanced our public API to enable users to:
 
 We've implemented the option for users to select their preferred scan profile to customize scan behavior according to their specific requirements. Users can choose from a selection of 8 different profiles for immediate and scheduled scans, with more to be added if needed. Notably, scan profiles are target-specific, with different profiles available for API and web targets.
 
-[For more information, have a look at the related docs.](https://docs.cobalt.io/platform-deep-dive/scans/#scan-profiles)
+{{% pageinfo color="info" %}}
+For more information, have a look at our [Scan Profiles documentation.](https://docs.cobalt.io/platform-deep-dive/scans/#scan-profiles)
+{{% /pageinfo %}}
 
 ![Scan Profiles](/release-notes/scan-profiles.png "Scan Profiles")
 

--- a/content/en/Product Updates/release-notes-october-2024.md
+++ b/content/en/Product Updates/release-notes-october-2024.md
@@ -34,5 +34,3 @@ For more information, have a look at our [Scan Profiles documentation.](https://
 
 ![Scan Profiles](/release-notes/scan-profiles.png "Scan Profiles")
 
----
-

--- a/content/en/Product Updates/release-notes-september-2024.md
+++ b/content/en/Product Updates/release-notes-september-2024.md
@@ -9,9 +9,7 @@ description: >-
 Explore What's New from Cobalt This Month
 {{% /pageinfo %}}
 
-### September 2024
-
-#### Updated Pentest Attestation Letters
+## Updated Pentest Attestation Letters
 
 We revamped the attestation letter's style for better PDF viewing and downloading, aligning it with our current brand guidelines.
 
@@ -19,7 +17,7 @@ We revamped the attestation letter's style for better PDF viewing and downloadin
 
 ---
 
-#### Enhanced Downloaded PDF Report Styles
+## Enhanced Downloaded PDF Report Styles
 
 Similar to the Attestation letter, our other report types' (Full Report, Full Report with Finding Details, Customer Letter, Attestation Report) PDF downloads required a makeover to ensure a refined appearance and improved clarity.
 
@@ -27,9 +25,9 @@ Similar to the Attestation letter, our other report types' (Full Report, Full Re
 
 ---
 
-#### Integration Builder Enhancements
+## Integration Builder Enhancements
 
-##### Assistant
+### Assistant
 
 _Problem:_
 The Integration Builder posed a learning curve for customers, requiring significant support before independent usage.
@@ -39,7 +37,7 @@ We’ve introduced an in-app assistant to guide customers in setting up new inte
 
 ![Integration Builder Assistant](/release-notes/integrations-builder-assistant.png "Integration Builder Assistant")
 
-##### Notification Management
+### Notification Management
 
 _Problem:_
 Customers were not receiving notifications about integration errors, leading to delayed issue identification and resolution.


### PR DESCRIPTION
Updating page headers to be consistent with the rest of the docs site and remove the header of the date name on each page as it is repetitive to the page titles.

Also cleaned up some section breaks that didn't belong.

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
