### PR TITLE
Styling Updates

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -130,6 +130,15 @@ nav.foldable-nav .with-child ul {
   -webkit-text-fill-color: transparent;
 }
 
+a {
+    color: #0047AB !important;
+    text-decoration: none;
+}
+
+a:hover {
+    color: #002243 !important;
+    text-decoration: none;
+}
 $bs-link-color: #0047AB;
 $bs-link-hover-color: #002243;
 

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -66,7 +66,7 @@ nav.foldable-nav .with-child ul {
 }
 
 .td-navbar {
-  box-shadow: 0 2px 10px rgba(0 70 168 .63) !important;
+  box-shadow: 0 2px 10px rgba(0, 70, 168, .63) !important;
 }
 
 .td-box--dark,.td-footer {

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -130,6 +130,9 @@ nav.foldable-nav .with-child ul {
   -webkit-text-fill-color: transparent;
 }
 
+$bs-link-color: #0047AB;
+$bs-link-hover-color: #002243;
+
 $td-enable-google-fonts: true;
 
 $google_font_name: "Inter";

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -17,10 +17,10 @@ nav ul li a {
 }
 
 .navbar-nav .nav-link {
-  color: #ffffff; // Change the default link color
+  color: #ffffff !important; // Change the default link color
 
   &:hover {
-    color: #002243; // Change the hover color
+    color: #002243 !important; // Change the hover color
 }
 }
 

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -65,6 +65,10 @@ nav.foldable-nav .with-child ul {
     margin-bottom: .5rem !important;
 }
 
+.td-navbar {
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.2);
+}
+
 .td-box--dark,.td-footer {
     color: #fff;
     background-color: #002243 !important; 

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -66,7 +66,7 @@ nav.foldable-nav .with-child ul {
 }
 
 .td-navbar {
-  box-shadow: 0 2px 10px rgb(0 70 168 / 63%) !important
+  box-shadow: 0 2px 10px rgba(0 70 168 .63) !important
 }
 
 .td-box--dark,.td-footer {

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -66,7 +66,7 @@ nav.foldable-nav .with-child ul {
 }
 
 .td-navbar {
-  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.2);
+  box-shadow: 0px 4px 8px rgba(0, 71, 171, 0.21) !important;
 }
 
 .td-box--dark,.td-footer {

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -66,7 +66,7 @@ nav.foldable-nav .with-child ul {
 }
 
 .td-navbar {
-  box-shadow: 0 2px 10px rgba(0 70 168 .63) !important
+  box-shadow: 0 2px 10px rgba(0 70 168 .63) !important;
 }
 
 .td-box--dark,.td-footer {

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -120,6 +120,12 @@ nav.foldable-nav .with-child ul {
   color: #000000;
 }
 
+.gradient-text {
+  background: linear-gradient(to right, #0047AB, #6500CC);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
 $td-enable-google-fonts: true;
 
 $google_font_name: "Inter";

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -56,7 +56,7 @@ nav.foldable-nav .ul-1 .with-child>label:before {
 }
 
 nav.foldable-nav .with-child ul {
-    margin-left: -1.5em !important;
+    margin-left: -.5em !important;
 }
 
 .td-sidebar-nav .td-sidebar-link.tree-root {

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -66,7 +66,7 @@ nav.foldable-nav .with-child ul {
 }
 
 .td-navbar {
-  box-shadow: 0px 4px 8px rgba(0, 71, 171, 0.21) !important;
+  box-shadow: 0 2px 10px rgb(0 70 168 / 63%) !important
 }
 
 .td-box--dark,.td-footer {

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -71,7 +71,7 @@ cascade:
   <div class="col-md-6">
     <div class="card">
       <div class="card-content">
-  <h3><b class="title-color">Try Our DAST Scanner</b></h3>        
+<h3><b class="gradient-text">Try Our DAST Scanner</b></h3>
         <p>Continuously monitor your attack surface and uncover vulnerabilities with Cobalt's automated DAST scans. Free unlimited scanning for one target.</p>
         <a href="/platform-deep-dive/scans/">Learn more »</a>
       </div>
@@ -80,7 +80,7 @@ cascade:
   <div class="col-md-6">
     <div class="card">
       <div class="card-content">
-<h3><b style="background: -webkit-linear-gradient(#0047AB, #6500CC); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">Try Engagements</b></h3>
+<h3><b class="gradient-text">Try Engagements</b></h3>
         <p>Go beyond pentesting with Cobalt engagements. Gain a deeper understanding of your security posture through comprehensive assessments like Secure Code Reviews and Digital Risk Assessments.</p>
         <a href="/cybersecurity-services/">Learn more »</a>
       </div>

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -80,7 +80,7 @@ cascade:
   <div class="col-md-6">
     <div class="card">
       <div class="card-content">
-  <h3><b class="title-color">Try Engagements</b></h3>        
+<h3><b style="background: -webkit-linear-gradient(#0047AB, #6500CC); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">Try Engagements</b></h3>
         <p>Go beyond pentesting with Cobalt engagements. Gain a deeper understanding of your security posture through comprehensive assessments like Secure Code Reviews and Digital Risk Assessments.</p>
         <a href="/cybersecurity-services/">Learn more »</a>
       </div>

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -11,6 +11,4 @@ s.parentNode.insertBefore(gcse, s);
 })();
 </script>
 			<gcse:searchresults-only></gcse:searchresults-only>
-{{ end }}
 
-{{ end }}

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,5 +1,4 @@
 {{ define "main" }}
-<section class="row td-search-result">
 <h2>{{ .Title }}</h2>
 {{ with .Site.Params.gcs_engine_id }}
 <script>
@@ -15,6 +14,5 @@ s.parentNode.insertBefore(gcse, s);
 </script>
 			<gcse:searchresults-only></gcse:searchresults-only>
 {{ end }}
-</section>
 
 {{ end }}

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,6 +1,5 @@
 {{ define "main" }}
 <section class="row td-search-result">
-<div class="col-12 col-md-8 offset-md-2">
 <h2 class="ml-4">{{ .Title }}</h2>
 {{ with .Site.Params.gcs_engine_id }}
 <script>
@@ -16,7 +15,6 @@ s.parentNode.insertBefore(gcse, s);
 </script>
 			<gcse:searchresults-only></gcse:searchresults-only>
 {{ end }}
-</div>
 </section>
 
 {{ end }}

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,4 +1,6 @@
-
+{{ define "main" }}
+<section class="row td-search-result">
+{{ with .Site.Params.gcs_engine_id }}
 <script>
 (function() {
 var cx = '{{ . }}';
@@ -11,4 +13,7 @@ s.parentNode.insertBefore(gcse, s);
 })();
 </script>
 			<gcse:searchresults-only></gcse:searchresults-only>
+{{ end }}
+</section>
 
+{{ end }}

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <section class="row td-search-result">
-<h2 class="ml-4">{{ .Title }}</h2>
+<h2>{{ .Title }}</h2>
 {{ with .Site.Params.gcs_engine_id }}
 <script>
 (function() {

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,6 +1,4 @@
-{{ define "main" }}
-<h2>{{ .Title }}</h2>
-{{ with .Site.Params.gcs_engine_id }}
+
 <script>
 (function() {
 var cx = '{{ . }}';


### PR DESCRIPTION
1. Updated the Navbar to add a dropshadow.
 
2. Updated the link styling for active and hover states to remove the bootstrap colors and replace them with our Cobalt blue for active and Navy blue for hover states.

3. Updated navbar links to add !important; to color specification to override global changes made above.

4. Fixed issue with navbar child pages not indenting when active and being flush to the left margin.

5. Added a class for gradient text and added it to style the homepage CTA's for Engagements and DAST.

6. Worked on expanding the 'Search Results' section to be closer to full-width.
- improved but not ideal after removing the 'ml-4' class it was wrapped in.
- still not displaying full width, has something to do with the right sidebar on this page that is now bumped up against the left sidebar, will dig back in after some of the heavier changes are done.

before:
![deploy-preview-580--cobalt-docs netlify app_search__q=pentest](https://github.com/user-attachments/assets/f4b6b19d-b79d-4b03-9082-6ee54fff42d6)

after:
![deploy-preview-580--cobalt-docs netlify app_search__q=pentest (1)](https://github.com/user-attachments/assets/39340e5d-d9be-46e8-80b1-f100b817f5b8)


## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
