### PR TITLE
[FX-4681]: fix typo in 'HTTP Connector' page

### DIFF
--- a/content/en/Integrations/IntegrationBuilder/How to Guides/http.md
+++ b/content/en/Integrations/IntegrationBuilder/How to Guides/http.md
@@ -267,7 +267,7 @@ You can also adjust the "Response content type" and the "Encoding" of the respon
 
 ##### Review the HTTP configuration
 
-> **❗** Exercise extra caution when working with production systems and using independent HTTP methods. You may want to cancel the wizard at this point and proceed with the configuration manually.
+> **❗** Exercise extra caution when working with production systems and using idempotent HTTP methods. You may want to cancel the wizard at this point and proceed with the configuration manually.
 
 When you click the "Send request" button, the HTTP action will send a request to the API with the specified body and any optional headers. Your authentication type and credentials will be used and verified when sending a sample request.
 


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| HTTP Connector | [Link](https://deploy-preview-583--cobalt-docs.netlify.app/integrations/integrationbuilder/how-to-guides/http/#review-the-http-configuration) | rename "independent HTTP methods" to "idempotent HTTP methods" |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text? (No, no links have changed.)

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
