### PR TITLE
adjust for new jira project names

### DIFF
--- a/.github/workflows/check-branch-name.yml
+++ b/.github/workflows/check-branch-name.yml
@@ -18,7 +18,7 @@ jobs:
 
           BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
           # Regex to match the Jira ticket naming convention.
-          REGEX="(revert|hotfix|no-ticket|dependabot)|([A-Z]|[a-z])+-[0-9]+"
+          REGEX="(revert|hotfix|no-ticket|dependabot)|([A-Z]|[a-z][0-9])+-[0-9]+"
 
           if [[ "${BRANCH_NAME}" =~ ${REGEX} ]]; then
             exit 0

--- a/.github/workflows/check-branch-name.yml
+++ b/.github/workflows/check-branch-name.yml
@@ -18,7 +18,7 @@ jobs:
 
           BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
           # Regex to match the Jira ticket naming convention.
-          REGEX="(revert|hotfix|no-ticket|dependabot)|([A-Z]|[a-z][0-9])+-[0-9]+"
+          REGEX="(chore|revert|hotfix|no-ticket|dependabot)|([A-Z]|[a-z]|[0-9])+-[0-9]+"
 
           if [[ "${BRANCH_NAME}" =~ ${REGEX} ]]; then
             exit 0


### PR DESCRIPTION
## Changelog
updating branch name check to allow for numbers in project/ticket

### Added
n/a

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

### Updated
n/a 

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
