### PR TITLE
[FX-4910] Remove extra host limit note

### DIFF
--- a/content/en/Platform Deep Dive/Scans/extra-hosts.md
+++ b/content/en/Platform Deep Dive/Scans/extra-hosts.md
@@ -19,9 +19,6 @@ Oftentimes, a web application will send requests to a domain that's different fr
 {{% image src="/deepdive/scans/extra-hosts/ExtraHosts_Create.png" alt="Extra Hosts form" %}}
 
 Every extra host needs to have a domain, which should not include a protocol. It's important for the domain to consist of a FQDN and an optional subdomain. During submission, the domain will be checked for reachability. If the domain is not reachable an error will show and prevent the extra host from getting created.
-{{% alert title="Note" color="primary" %}}
-A maximum of 5 extra hosts can be added per target. Contact support to add more.
-{{% /alert %}}
 
 Extra hosts can be configured similarly to API targets, although the options are more restricted. If needed, an extra host can be provided with custom headers and cookies. These can be used for any kind of purpose, ranging from authentication to security requirements.
 


### PR DESCRIPTION
Ticket: https://zombie.atlassian.net/browse/FX-4910

## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Extra hosts | [Link](https://deploy-preview-595--cobalt-docs.netlify.app/platform-deep-dive/scans/extra-hosts/#configuration) | Removed the alert |

### Before
![Screenshot 2025-01-03 at 11 37 25](https://github.com/user-attachments/assets/c8e80193-ac3d-4807-a1a0-77ae1572f5d5)

### After
![Screenshot 2025-01-03 at 11 42 55](https://github.com/user-attachments/assets/e61ad337-45e6-4395-86d8-bcc6c4f2f86d)

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
