### PR TITLE
[FX-5255] Update reference to Jira Server to just DC

### DIFF
--- a/content/en/Integrations/IntegrationBuilder/How to Guides/jira-cloud-migration.md
+++ b/content/en/Integrations/IntegrationBuilder/How to Guides/jira-cloud-migration.md
@@ -10,7 +10,7 @@ description: >
 
 This guide is designed to help organizations transition from our native **Jira Cloud** integration to our highly customizable [**Integration Builder**](/integrations/integrationbuilder/).
 
-> **⚠️** This migration guide is not applicable if your organization uses **Jira Server** or **Jira Data Center**.
+> **⚠️** This migration guide is not applicable if your organization uses **Jira Data Center**.
 
 {{% /pageinfo %}}
 


### PR DESCRIPTION
## Changelog

### Updated

- Removed reference to 'Jira Server', as that has been retired by Atlassian

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
