### PR TITLE
Updating January Release Notes with DAST Blackout Periods

### DIFF
--- a/content/en/Product Updates/release-notes-january-2025.md
+++ b/content/en/Product Updates/release-notes-january-2025.md
@@ -14,11 +14,11 @@ Explore What's New from Cobalt This Month
 
 <strong>Problem</strong>
 - Customers needed a way to pause DAST scans during maintenance, high-traffic events, or other sensitive times to avoid conflicts, performance issues, or inaccurate results. Previously, they had to manually pause scans + resume them later, which was inconvenient and could lead to missed vulnerabilities if scans weren't restarted.
-- (Bonus: Timestamps + inputs were set in UTC, which is not as accessible and required some extra thinkin' to translate to local timezones).
+- Timestamps + inputs were set in UTC, which is not as accessible and required some extra thinkin' to translate to local timezones.
 
 <strong>Solution</strong>
 - The Blackout Period feature (located in the target settings) allows customers to schedule specific times and days for scans to be automatically paused and resumed, eliminating the need for manual intervention.
-- (Bonus: all timestamps + inputs within the DAST UI are displayed to the user in their local timezone)
+- All timestamps + inputs within the DAST UI are now displayed to the user in their local timezone.
 
 <strong>Benefits</strong>
 - <strong>Convenience + Automation:</strong> No more manual stopping and starting of scans.

--- a/content/en/Product Updates/release-notes-january-2025.md
+++ b/content/en/Product Updates/release-notes-january-2025.md
@@ -13,12 +13,12 @@ Explore What's New from Cobalt This Month
 ## DAST Release: Blackout Period
 
 <strong>Problem</strong>
-<p>- Customers needed a way to pause DAST scans during maintenance, high-traffic events, or other sensitive times to avoid conflicts, performance issues, or inaccurate results. Previously, they had to manually pause scans + resume them later, which was inconvenient and could lead to missed vulnerabilities if scans weren't restarted.
-- (Bonus: Timestamps + inputs were set in UTC, which is not as accessible and required some extra thinkin' to translate to local timezones).</p>
+- Customers needed a way to pause DAST scans during maintenance, high-traffic events, or other sensitive times to avoid conflicts, performance issues, or inaccurate results. Previously, they had to manually pause scans + resume them later, which was inconvenient and could lead to missed vulnerabilities if scans weren't restarted.
+- (Bonus: Timestamps + inputs were set in UTC, which is not as accessible and required some extra thinkin' to translate to local timezones).
 
 <strong>Solution</strong>
-<p>- The Blackout Period feature (located in the target settings) allows customers to schedule specific times and days for scans to be automatically paused and resumed, eliminating the need for manual intervention.
-- (Bonus: all timestamps + inputs within the DAST UI are displayed to the user in their local timezone)</p>
+- The Blackout Period feature (located in the target settings) allows customers to schedule specific times and days for scans to be automatically paused and resumed, eliminating the need for manual intervention.
+- (Bonus: all timestamps + inputs within the DAST UI are displayed to the user in their local timezone)
 
 <strong>Benefits</strong>
 - <strong>Convenience + Automation:</strong> No more manual stopping and starting of scans.

--- a/content/en/Product Updates/release-notes-january-2025.md
+++ b/content/en/Product Updates/release-notes-january-2025.md
@@ -10,6 +10,31 @@ Explore What's New from Cobalt This Month
 {{% /pageinfo %}}
 
 
+## DAST Release: Blackout Period
+
+<strong>Problem</strong>
+<p>- Customers needed a way to pause DAST scans during maintenance, high-traffic events, or other sensitive times to avoid conflicts, performance issues, or inaccurate results. Previously, they had to manually pause scans + resume them later, which was inconvenient and could lead to missed vulnerabilities if scans weren't restarted.
+- (Bonus: Timestamps + inputs were set in UTC, which is not as accessible and required some extra thinkin' to translate to local timezones).</p>
+
+<strong>Solution</strong>
+<p>- The Blackout Period feature (located in the target settings) allows customers to schedule specific times and days for scans to be automatically paused and resumed, eliminating the need for manual intervention.
+- (Bonus: all timestamps + inputs within the DAST UI are displayed to the user in their local timezone)</p>
+
+<strong>Benefits</strong>
+- <strong>Convenience + Automation:</strong> No more manual stopping and starting of scans.
+- <strong>Flexibility:</strong> Customers can define blackout periods that precisely match their needs.
+- <strong>Continuous Security:</strong> Ensures critical security testing windows are maintained, as scans automatically resume.
+- <strong>Efficiency:</strong> Prevents wasted time + resources on scans that might be affected by temporary events or maintenance activities.
+- <strong>Peace of Mind:</strong> Customers can confidently schedule maintenance or other activities without worrying about disrupting their security scans or missing potential vulnerabilities.
+
+{{% pageinfo color="blue" %}}
+For more information, have a look at our [Blackout Period documentation.](https://docs.cobalt.io/platform-deep-dive/scans/blackout-period/)
+{{% /pageinfo %}}
+
+{{% image src="/deepdive/scans/blackout-period-enabled.png" alt="Blackout Period - Enabled" %}}
+
+---
+
 ## Ticketing Integration for Carried Over Findings
 
 <strong>Problem</strong>


### PR DESCRIPTION
Added the release note to January 2025 to cover the DAST Blackout Period information for our customers.

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
