### PR TITLE
Add break in Jira DC page

### DIFF
--- a/content/en/Integrations/Jira/jira-server-dc.md
+++ b/content/en/Integrations/Jira/jira-server-dc.md
@@ -25,7 +25,7 @@ If your organization uses Jira Cloud, see [Jira Cloud Integration](/integrations
 1. Under **What type of Jira setup are you using?**, select **Jira Data Center**.
     {{% image src="/integrations/configure-jira-dc-integration.png" alt="Select to configure the integration with Jira Data Center in Cobalt" %}}
 1. Follow the instructions in the UI to install and connect the [Cobalt for Jira DC](https://marketplace.atlassian.com/apps/1224424/cobalt-for-jira-dc-server?tab=overview&hosting=datacenter) plugin.
-1. Return to the Cobalt app, and check the integration status. You should see your Jira instance on the **Jira Integration** page.
+1. Return to the Cobalt app, and check the integration status. You should see your Jira instance on the **Jira Integration** page.<br>
     {{% image src="/integrations/jira-integration-status.png" alt="Jira integration status in Cobalt" %}}
 
 ### Step 2: Configure the Integration for a Pentest


### PR DESCRIPTION
## Changelog

### Added

- A break between text and image

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
