### PR TITLE
As a user, I want to read documentation on how to export my Cobalt data out of the platform

### DIFF
--- a/content/en/Platform Deep Dive/Organization/your-contract.md
+++ b/content/en/Platform Deep Dive/Organization/your-contract.md
@@ -50,9 +50,9 @@ Once the grace period is over, we revoke access to the platform from all organiz
 To renew your contract, reach out to your Customer Success Manager or support@cobalt.io.
 {{< /alert >}}
 
-## Download Your Organization's Pentest Data
+## Download Your Organization's Data
 
-To export pentest data for your organization, you can:
+To export data for your organization, you can:
 
 - Use the Cobalt API. Read our [API documentation](/cobalt-api/documentation/v2) for details. You can send API requests to retrieve pentest data, such as:
   - [All pentests](/cobalt-api/documentation/v2/#get-all-pentests)


### PR DESCRIPTION
## Changelog

### Added

- Instructions to export the following data:
 - Domains
 - Engagement reports
 - All or filtered findings
 - DAST Reports
 - Credits
 - Insights

### Updated

- Made the text more broadly referencing org data rather than specifically just to pentest data

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
