### PR TITLE
Add callout for global MFA enforcement

### DIFF
--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -53,6 +53,13 @@ To manage two-factor authentication (2FA) settings for your account, select **Se
 
 ### Two-Factor Authentication
 
+{{% alert title="Note" color="primary" %}}
+
+Starting March 19 all users signing in with username/password will be required to set up a 2FA method.
+If you don't have 2FA configured by then, you will be asked to configure it the next time you sign in.
+
+{{% /alert %}}
+
 #### Enable Two-Factor Authentication
 
 If you're **signing in with your email and password**, you can enable two-factor authentication (2FA) to protect your account. 2FA adds another layer of security to your account by requiring more than just a password to sign in.

--- a/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
+++ b/content/en/Platform Deep Dive/Cobalt Account/account-settings.md
@@ -55,7 +55,7 @@ To manage two-factor authentication (2FA) settings for your account, select **Se
 
 {{% alert title="Note" color="primary" %}}
 
-Starting March 19 all users signing in with username/password will be required to set up a 2FA method.
+Starting March 19, all users signing in with a username/password will be required to set up a 2FA method.
 If you don't have 2FA configured by then, you will be asked to configure it the next time you sign in.
 
 {{% /alert %}}


### PR DESCRIPTION
## Changelog

<img width="864" alt="image" src="https://github.com/user-attachments/assets/aac8c8af-635e-407e-98c5-64e1e7bd0b1c" />

###  Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Callout for global MFA enforcement | [Link](https://deploy-preview-626--cobalt-docs.netlify.app/platform-deep-dive/cobalt-account/account-settings/#two-factor-authentication) | This callout will be removed again after the given date |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
