### PR TITLE
chore/SS2-1062/hide-nav-pages

### DIFF
--- a/content/en/Cybersecurity Services/_index.md
+++ b/content/en/Cybersecurity Services/_index.md
@@ -2,6 +2,7 @@
 title: "Cybersecurity Services"
 linkTitle: "Cybersecurity Services"
 weight: 6
+toc_hide: = true
 no_list: true
 description: >
   Run engagements with the Cobalt Cybersecurity Services team.

--- a/content/en/Methodologies/azure-ad.md
+++ b/content/en/Methodologies/azure-ad.md
@@ -1,6 +1,7 @@
 ---
 title: "Azure Active Directory Penetration Testing Methodologies"
 linkTitle: "Azure AD Methodologies"
+toc_hide: = true
 weight: 0
 description: >
   Review Cobalt pentest methodologies for Azure Active Directory.

--- a/content/en/Methodologies/cloud.md
+++ b/content/en/Methodologies/cloud.md
@@ -1,7 +1,7 @@
 ---
 title: "Cloud Configuration Pentests"
 linkTitle: "Cloud Configuration Pentest Methodologies"
-toc_hide = true
+toc_hide: = true
 description: >
   Review methodologies for Cloud Configurations.
 aliases:

--- a/content/en/Methodologies/cloud.md
+++ b/content/en/Methodologies/cloud.md
@@ -1,7 +1,7 @@
 ---
 title: "Cloud Configuration Pentests"
 linkTitle: "Cloud Configuration Pentest Methodologies"
-weight: 0
+toc_hide = true
 description: >
   Review methodologies for Cloud Configurations.
 aliases:

--- a/hugo.toml
+++ b/hugo.toml
@@ -63,7 +63,7 @@ weight = 1
 description = "Documentation for Penetration testing as a Service"
 time_format_default = "January 02, 2006"
 time_format_blog = "01.02.2006"
-
+hidden = "true"
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
Hiding certain pages from our left side navigation menu:
- Cloud
- Azure
- CyberSecurity Services

Added the front matter toc_hide: = true to achieve this.

---

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
