### PR TITLE
[CX-526] setup new Create Pentest page

### DIFF
--- a/content/en/CreatePentest/_index.md
+++ b/content/en/CreatePentest/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Create Pentest"
+linkTitle: "Create Pentest"
+no_list: true
+weight: 4
+description: >
+  Create and plan your pentest with Cobalt.
+---
+
+Take your first steps to get started:
+
+- [Launch a pentest](#launch-a-pentest)
+
+## Launch a new pentest
+
+To create a new pentest, first you should <a href="/platform-deep-dive/assets/#create-an-asset">create the asset</a> you wish to test
+
+- Now, you’re ready to launch your new pentest.
+1. On the Pentests page, select Create a Pentest.
+2. A modal will ask you if you want to Start from Scratch or Copy from Previous Pentest. 
+    a. <b>Start from scratch:</b> select the asset you want to test
+    b. <b>Copy from previous pentest:</b> select the pentest you wish to copy. This will copy most of the information except for information we need specific to each pentest e.g. credentials or point of contact
+3. Select Confirm to start filling out the pentest

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -37,6 +37,13 @@ cascade:
      </div>
      <div class="feature col">
        <div class="feature-icon d-inline-flex align-items-left justify-content-left bg-gradient fs-2 mb-3">
+         <a href="/create-pentest/" tabindex="-1" aria-hidden="true"><img src="/homepage/methodologies.svg" alt="Create Pentest" title="Create Pentest"></a>
+       </div>
+       <h4><a href="/create-pentest/" class="custom-link-color"><b>Create Pentest</b></a></h4>
+       <p>Learn about all aspects of planning a pentest.</p>
+     </div>
+     <div class="feature col">
+       <div class="feature-icon d-inline-flex align-items-left justify-content-left bg-gradient fs-2 mb-3">
          <a href="/platform-deep-dive/pentests/pentest-types/" tabindex="-1" aria-hidden="true"><img src="/homepage/pentest-types.svg" alt="Pentest Types" title="Pentest Types"></a>
        </div>
        <h4><a href="/platform-deep-dive/pentests/pentest-types/" class="custom-link-color"><b>Pentest Types</b></a></h4>


### PR DESCRIPTION
## Changelog

### Added

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
