### PR TITLE
Fix homepage redirect to pentest types

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -39,7 +39,7 @@ cascade:
        <div class="feature-icon d-inline-flex align-items-left justify-content-left bg-gradient fs-2 mb-3">
          <a href="/platform-deep-dive/pentests/pentest-types/" tabindex="-1" aria-hidden="true"><img src="/homepage/pentest-types.svg" alt="Pentest Types" title="Pentest Types"></a>
        </div>
-       <h4><a href="/platform-deep-dive/pentests/pentest-types/" class="custom-link-color"><b>Pentest Types</b></a></h4>
+       <h4><a href="/pentests/create-pentest/#3-set-the-test-focus" class="custom-link-color"><b>Pentest Types</b></a></h4>
        <p>Learn about the pentest types that we offer. Make your security stronger with Agile and Comprehensive Pentests.</p>
      </div>
    </div>


### PR DESCRIPTION
## Changelog

### Added

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
