### PR TITLE
Update Cobalt bot name to Cobalt Offensive Security

### DIFF
--- a/content/en/Integrations/ms-teams.md
+++ b/content/en/Integrations/ms-teams.md
@@ -19,9 +19,9 @@ Learn how to set up an integration between Cobalt and Microsoft Teams. The avail
 Integrate with Microsoft Teams to seamlessly collaborate with Cobalt pentesters and other pentest team members directly from Teams.
 
 ### How it Works
-- Install the Cobalt app, from the Microsoft Teams app store, into your Teams environment
-- In Teams, a channel manager adds the Cobalt app to a Teams channel, authenticates to Cobalt, and selects the specific pentest to connect to the channel
-- Members of the Teams channel can use the Cobalt app to post or reply to messages, directly from Teams
+- Install the Cobalt Offensive Security app, from the Microsoft Teams app store, into your Teams environment
+- In Teams, a channel manager adds the Cobalt Offensive Security app to a Teams channel, authenticates to Cobalt, and selects the specific pentest to connect to the channel
+- Members of the Teams channel can use the Cobalt Offensive Security app to post or reply to messages, directly from Teams
 - Pentest team members with a Cobalt account, as well as Cobalt’s pentesters and staff, can see, respond, or send new messages from Cobalt’s Pentest Chat, which are syndicated to the connected Teams channels
 - Pentester Updates are sent to the channel(s) connected to that specific pentest
 
@@ -36,36 +36,36 @@ Please be aware of the following considerations when using this integration. We 
 Connect your Microsoft Teams workspace to your Cobalt Organization in order to sync Cobalt pentests chat with Teams channels, allowing your team to collaborate on a test directly from your Teams instance. 
 
 ### Install Cobalt Teams Application in Your Teams Instance
-As an administrator for your Microsoft Teams instance, you can add the Cobalt app to your environment by:
+As an administrator for your Microsoft Teams instance, you can add the Cobalt Offensive Security app to your environment by:
 1. Go to Apps within your Microsoft Teams interface
-2. Search “Cobalt Pentesting and Offensive Security”
+2. Search "Cobalt Offensive Security"
 3. Click “Add”
 
 ### Uninstall Teams Integration
-To remove the Cobalt app from your Microsoft Teams instance: 
+To remove the Cobalt Offensive Security app from your Microsoft Teams instance: 
 1. Navigate to the "Apps" section within Microsoft Teams, then "Manage your apps".
-2. Find the Cobalt Pentesting and Offensive Security app; expand it to see where it's used. 
+2. Find the Cobalt Offensive Security app; expand it to see where it's used. 
 3. Click the trash can icon to remove from each channel as needed. 
 Note: If you're a Teams Administrator, you can also remove apps from the Teams admin center.
 
-Here’s what to expect once you’ve removed the Cobalt app:
+Here’s what to expect once you’ve removed the Cobalt Offensive Security app:
 - Data synchronization between Cobalt and Microsoft Teams stops.
 - All channel connections for specific pentests are deleted. If you decide to reinstall the integration, you’ll need to set up the connection for each pentest.
 - Any previously posted messages from Cobalt to your Teams channels will remain visible in Teams. 
 - Posting new messages, or responding to previously posted pentest messages in Teams, will no longer be possible. 
 
 ## Connect Channels
-Once you’ve installed the Cobalt app in your Microsoft Teams instance, you can connect a Teams channel to a pentest, so your teams and pentesters can seamlessly collaborate directly from the Teams channel or through the Cobalt platform. 
+Once you’ve installed the Cobalt Offensive Security app in your Microsoft Teams instance, you can connect a Teams channel to a pentest, so your teams and pentesters can seamlessly collaborate directly from the Teams channel or through the Cobalt platform. 
 
 ### Connect a Teams Channel to a Pentest
 To communicate with the Cobalt pentest team through Microsoft Teams, you must connect a Teams channel to a specific Cobalt pentest. The person who sets up the Teams channel connection must have a Cobalt account which has access to the Cobalt pentest.
 
-1. Go to the Teams channel which you wish to connect to a pentest, and add the “Cobalt Pentesting and Offensive Security” app
-2. Type “@Cobalt connect”
+1. Go to the Teams channel which you wish to connect to a pentest, and add the "Cobalt Offensive Security" app
+2. Type “@Cobalt Offensive Security connect”
 3. In the bot response, which shows instructions to set up the connection, click “Login & Select Test”
 4. Sign in to the Cobalt platform
 5. Select the pentest you wish to connect to the Teams channel
-6. Review the confirmation message from the Cobalt bot to verify the correct pentest has been connected to the channel. 
+6. Review the confirmation message from the Cobalt Offensive Security bot to verify the correct pentest has been connected to the channel. 
 Note:  Only one pentest can be connected to a Teams channel.  
 
 ### Disconnect Teams Channel(s)
@@ -75,20 +75,20 @@ Once you’ve connected your Microsoft Teams instance, you can view all pentests
 2. Click “Disconnect” beside the desired pentest to remove the Teams connection.
 3. If disconnection was successful, in the Teams channel, a new post will confirm that the channel is no longer connected.
 
-You may also disconnect directly from Teams, by going to the desired channel, and using the bot command “@Cobalt disconnect”. 
+You may also disconnect directly from Teams, by going to the desired channel, and using the bot command “@Cobalt Offensive Security disconnect”. 
 
 ### Send a Message from Teams
 Once a Teams channel has been connected to a Cobalt pentest, you can send messages to the pentest chat directly from Teams. 
 
-1. In the Teams channel, click the “Cobalt” icon in the Compose Message box
+1. In the Teams channel, click the "Cobalt Offensive Security" icon in the Compose Message box
 2. Enter your message in the “Send Message” dialog box
 3. Click “Send”
 
-You can also use the bot command “@Cobalt chat” then type your message. 
+You can also use the bot command “@Cobalt Offensive Security chat” then type your message. 
 Once sent, the message will appear in the Cobalt Chat for the associated pentest, and will be syndicated to your Teams channel for visibility to the other channel members. 
 
 ### Get Help within Teams
-You can also use the bot command “@Cobalt help” to view a list of the available commands and what they are used for.
+You can also use the bot command “@Cobalt Offensive Security help” to view a list of the available commands and what they are used for.
 
 ### Pentester Updates in Teams
 If a Teams channel has been connected to a Cobalt pentest, during the course of the pentest, updates posted by pentesters will be sent as messages to the connected channel(s). 
@@ -99,7 +99,7 @@ If you have issues or need support, contact support@cobalt.io.
 ## Frequently Asked Questions
 **Q: Do all messages in my Teams channel get synced to the Cobalt pentest?**
 
-A: No. Only messages or replies sent using the Cobalt bot will be synced to Cobalt.  Any other communication within the channel, using the standard Teams messaging features, will remain private to that channel, and are not visible to Cobalt. 
+A: No. Only messages or replies sent using the Cobalt Offensive Security bot will be synced to Cobalt.  Any other communication within the channel, using the standard Teams messaging features, will remain private to that channel, and are not visible to Cobalt. 
 
 
 **Q: Do I need to provide pentesters and Cobalt staff with access to Microsoft Teams?**
@@ -114,7 +114,7 @@ A: No. You can invite anybody you wish from your organization to the Teams chann
 
 **Q: Can Cobalt access data in my Microsoft Teams instance when I use this integration?**
 
-A: No. Cobalt has no visibility or access to your Teams system, except for messages posted using the Cobalt bot.
+A: No. Cobalt has no visibility or access to your Teams system, except for messages posted using the Cobalt Offensive Security bot.
 
 
 **Q: Where do messages sent from Teams appear in the Cobalt platform?**
@@ -124,7 +124,7 @@ A: Messages are synchronized to the Cobalt Chat for the pentest or engagement th
 
 **Q: Who can see the messages sent using the integration?**
 
-A: Messages sent to Cobalt from the Teams bot will be visible to Cobalt users who have been granted access to the associated pentest (including your Cobalt Staff members, Pentesters, and any team members that you have invited to the pentest in the Cobalt platform).  After you’ve connected a Teams channel to a pentest, messages posted using the Cobalt bot will be syndicated to the connected pentest’s InApp chat on the Cobalt platform, and vice versa. Users with access to the Teams channel will be able to see the messages originating from the Cobalt InApp chat on the connected pentest. 
+A: Messages sent to Cobalt from the Teams bot will be visible to Cobalt users who have been granted access to the associated pentest (including your Cobalt Staff members, Pentesters, and any team members that you have invited to the pentest in the Cobalt platform).  After you’ve connected a Teams channel to a pentest, messages posted using the Cobalt Offensive Security bot will be syndicated to the connected pentest’s InApp chat on the Cobalt platform, and vice versa. Users with access to the Teams channel will be able to see the messages originating from the Cobalt InApp chat on the connected pentest. 
 
 
 **Q: How do I control who sees the Cobalt discussions in Teams?**


### PR DESCRIPTION
## Changelog

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| MS Teams | [Link](https://deploy-preview-670--cobalt-docs.netlify.app/integrations/ms-teams/) | This is the name we agreed on at the end https://docs.google.com/document/d/1t9p4ww3FfXDs5O_3MPF1ufs_2p-l98On8KdZptFvDCA/edit?tab=t.0 |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
