### PR TITLE
Remove docs related to browser verification flow

### DIFF
--- a/content/en/Account/account-recovery.md
+++ b/content/en/Account/account-recovery.md
@@ -25,7 +25,6 @@ Follow these instructions if you can't sign in to Cobalt because:
 - You [forgot your password](#forgot-your-password)
 - Your [account isn't fully set up](#account-isnt-fully-set-up)
 - Your [email or password is invalid](#email-or-password-is-invalid)
-- [We don't recognize your browser](#we-dont-recognize-your-browser)
 - You have [problems with SAML SSO](#cant-sign-in-using-saml-sso)
 - You're [locked out of your account](#locked-out-of-your-account)
 - [The sign-in page doesn't load](#the-sign-in-page-doesnt-load)
@@ -122,32 +121,6 @@ Possible problems:
 - If the invitation link in the email has expired, ask your Organization Owner to invite you once again.
   - If you're an Organization Owner: To resend an invitation to a user, [remove them from your organization](/platform-deep-dive/organization/manage-users/#remove-users), and then [invite](/platform-deep-dive/organization/manage-users/#invite-users) them again.
   - If you're the only Organization Owner in your organization: To get help, contact your Customer Success Manager (CSM) or support@cobalt.io.
-
-## We Don't Recognize Your Browser
-
-{{% browser-verification-intro %}}
-
-When you see the **Verify Your Browser** message upon signing in, do the following:
-
-1. Check your email that you used to sign in to Cobalt.
-1. In the email prompting you to verify your browser, double-check the details of your last sign-in attempt, and select **Verify Browser**.
-   - If you don't recognize this sign-in attempt, do the following:
-     - Contact {{% csm-support %}}. {{% compromised-account-action %}}
-     - [Change your password](/platform-deep-dive/cobalt-account/account-settings/#change-your-password), and [reset two-factor authentication](/platform-deep-dive/cobalt-account/account-settings/#reset-two-factor-authentication).
-   - Make sure to verify your browser before the link in the email expires.
-1. We save the browser information and sign you in to the Cobalt app.
-   - You get an email confirming that we verified your new browser.
-   - Next time you sign in from this browser, you don't need to verify it again.
-
-To enhance your account security, we recommend that you [enable two-factor authentication](/platform-deep-dive/cobalt-account/account-settings/#enable-two-factor-authentication).
-
-**Troubleshooting tips**:
-
-- Make sure that cookies are turned on for the `cobalt.io` site in your browser. To turn on cookies, follow the instructions for your browser. Here are instructions for some popular browsers:
-  - [Google Chrome](https://support.google.com/accounts/answer/61416)
-  - [Firefox](https://support.mozilla.org/en-US/kb/websites-say-cookies-are-blocked-unblock-them)
-  - [Safari](https://support.apple.com/en-au/guide/safari/ibrw850f6c51/mac)
-- The subject line of the email we send is `[Cobalt] Verify Browser`. Search for this email in your mailbox. If you're not receiving emails from Cobalt, see our [troubleshooting tips](/platform-deep-dive/collaboration/manage-notifications/#troubleshoot-email-notifications).
 
 ## Can't Sign In Using SAML SSO
 

--- a/content/en/Account/sign-in.md
+++ b/content/en/Account/sign-in.md
@@ -64,11 +64,3 @@ We support two-factor authentication (2FA) **for users who sign in with their em
 {{< alert title="Tip" color="primary" >}}
 {{% 2fa-see-troubleshooting %}}
 {{< /alert >}}
-
-## Browser Verification
-
-{{% browser-verification-intro %}}
-
-{{< alert title="Tip" color="primary" >}}
-If you see the **Verify Your Browser** message upon signing in, follow the steps described in [We Don't Recognize Your Browser](/account/account-recovery/#we-dont-recognize-your-browser).
-{{< /alert >}}

--- a/layouts/shortcodes/browser-verification-intro.md
+++ b/layouts/shortcodes/browser-verification-intro.md
@@ -1,8 +1,0 @@
-When you sign in to Cobalt, we record information about your browser to add an extra layer of security to the sign-in process. This setting is based on cookies and is **not** related to 2FA or SAML SSO.
-
-If you attempt to sign in from a device or browser that we don't recognize, we take additional steps to verify your identity before granting you access. This happens when you:
-
-- Sign in from a new device or browser
-- Use your browser's private (incognito) mode
-- Clear or turn off cookies in your browser
-- Sign in from a different system


### PR DESCRIPTION
## Changelog

### Added

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

### Updated

| Page | Deploy Preview | Comment |
| ----- | ----- | ----- |
| Name | Link | Comment |

## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
