### PR TITLE
Update old Entity ID with new one

### DIFF
--- a/content/en/Organization/Organization Settings/SAML SSO/_index.md
+++ b/content/en/Organization/Organization Settings/SAML SSO/_index.md
@@ -60,7 +60,7 @@ Here’s a general configuration workflow for SAML SSO:
 1. Complete the configuration in the identity provider system. Enter the following values from Cobalt:
     - **ACS URL**: (unique value for each organization).
       - Example: `https://login.app.us.cobalt.io/login/callback?connection=example-org`, where the string after `=` is the organization's **slug** (`example-org`).
-    - **Entity ID**: `https://api.us.cobalt.io/users/saml/metadata`
+    - **Entity ID**: `https://api.us.cobalt.io/v2/orgs/<your-org's-slug>/saml_metadata`
     - **Metadata**: If your identity provider requires the SAML metadata file, it can be obtained at the following URL.
       - Example: `https://login.app.us.cobalt.io/samlp/metadata?connection=example-org`, where the string after `=` is the organization's **slug** (`example-org`).
 1. Test your SAML configuration.
@@ -133,8 +133,8 @@ To configure SAML SSO with Azure Active Directory (Azure AD):
     - On the application page, select **Set up single sign-on**.
     - On the **Select a single sign-on method** screen, select **SAML**.
     - Under **Basic SAML Configuration**, enter:
-       - **Identifier (Entity ID)**: `https://api.us.cobalt.io/users/saml/metadata`
-         - For EU data center: `https://api.eu.cobalt.io/users/saml/metadata`
+       - **Identifier (Entity ID)**: `https://api.us.cobalt.io/v2/orgs/<your-org's-slug>/saml_metadata`
+         - For EU data center: `https://api.eu.cobalt.io/v2/orgs/test-org-api/saml_metadata`
        - **Reply URL** (Assertion Consumer Service URL): **ACS URL** from Cobalt (unique value for each organization).<br>Copy the value in the Cobalt app in **Settings** > **Identity & Access** > **Configure SAML**.
        - **Sign on URL**: Leave this field blank.
        - **Relay State**: Leave this field blank.
@@ -172,8 +172,8 @@ To create a SAML app for Cobalt in Duo:
 1. Still in Cobalt, copy the **ACS URL** value, then select **Save Configuration**.
 1. Go back to Duo. Under **Service Provider**, enter:
     - **ACS URL**: **ACS URL** from Cobalt.
-    - **Entity ID**: `https://api.us.cobalt.io/users/saml/metadata`
-      - For EU data center: `https://api.eu.cobalt.io/users/saml/metadata`
+    - **Entity ID**: `https://api.us.cobalt.io/v2/orgs/<your-org's-slug>/saml_metadata`
+      - For EU data center: `https://api.eu.cobalt.io/v2/orgs/test-org-api/saml_metadata`
 1. In Duo, complete the **SAML Response** section with:
     - **NameID format**: `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`
     - **NameID attribute**: `mail`
@@ -208,8 +208,8 @@ To create a SAML app for Cobalt in the Google Admin console:
 1. Still in Cobalt, copy the **ACS URL** value, then select **Save Configuration**.
 1. Go back to the Google Admin console. In the **Service Provider Details** window, enter:
     - **ACS URL**: **ACS URL** from Cobalt
-    - **Entity ID**: `https://api.us.cobalt.io/users/saml/metadata`
-      - For EU data center: `https://api.eu.cobalt.io/users/saml/metadata`
+    - **Entity ID**: `https://api.us.cobalt.io/v2/orgs/<your-org's-slug>/saml_metadata`
+      - For EU data center: `https://api.eu.cobalt.io/v2/orgs/test-org-api/saml_metadata`
 1. Leave the **Signed Response** option unselected (default).
 1. On the **Attribute Mapping** page, add an attribute `email`, and select **Basic Information** and **Primary Email**.
 1. Complete other required steps.
@@ -242,8 +242,8 @@ To create a non-gallery SAML app for Cobalt in Okta:
 1. On the **General Settings** tab, enter general information for the integration, then select **Next**.
 1. On the **Configure SAML** tab, under **General**, enter SAML details:
     -  **Single sign-on URL**: Enter **ACS URL** from Cobalt.
-    - **Audience URI (SP Entity ID)**: Enter `https://api.us.cobalt.io/users/saml/metadata`.
-      - For EU data center: `https://api.eu.cobalt.io/users/saml/metadata`
+    - **Audience URI (SP Entity ID)**: Enter `https://api.us.cobalt.io/v2/orgs/<your-org's-slug>/saml_metadata`.
+      - For EU data center: `https://api.eu.cobalt.io/v2/orgs/test-org-api/saml_metadata`
     - Leave the **Default RelayState** field blank.
     - For other fields, use default values.<br><br>
     ![Configure a non-gallery SAML app in Okta](/deepdive/configure-non-gallery-SAML-app-in-Okta-2.png "Configure a non-gallery SAML app in Okta")
@@ -274,8 +274,8 @@ To configure SAML SSO with OneLogin:
 
 1. Create a custom application connector for Cobalt. Follow OneLogin instructions to [build a SAML Custom Connector (Advanced)](https://onelogin.service-now.com/support?id=kb_article&sys_id=912bb23edbde7810fe39dde7489619de&kb_category=93e869b0db185340d5505eea4b961934).
 1. In OneLogin, enter the following values for configuration parameters:
-    - **Audience (EntityID)**: `https://api.us.cobalt.io/users/saml/metadata`
-      - For EU data center: `https://api.eu.cobalt.io/users/saml/metadata`
+    - **Audience (EntityID)**: `https://api.us.cobalt.io/v2/orgs/<your-org's-slug>/saml_metadata`
+      - For EU data center: `https://api.eu.cobalt.io/v2/orgs/test-org-api/saml_metadata`
     - **Recipient**, **ACS (Consumer) URL Validator**, and **ACS (Consumer) URL**: ACS URL (unique value for each organization).<br>Copy the value in the Cobalt app in **Settings** > **Identity & Access** > **Configure SAML**.
     - **SAML initiator**: OneLogin
     - **SAML nameID format**: Email

--- a/content/en/Organization/Organization Settings/SAML SSO/saml-migration.md
+++ b/content/en/Organization/Organization Settings/SAML SSO/saml-migration.md
@@ -24,8 +24,8 @@ Here is a summary of updates:
 - Our **Assertion Consumer Service (ACS) URL** is no longer `https://api.cobalt.io/users/saml/auth`, but is now unique per organization. To get your unique ACS URL, go to **Settings** > **Identity & Access** > **Configure SAML** in the Cobalt app.
   - Example ACS URL: `https://login.app.us.cobalt.io/login/callback?connection=example-org`, where the string after `=` is the organization's **slug** (`example-org`). You can also see the slug in **Settings** > **General**.
 - Our **Audience Restriction** now contains a location subdomain.
-  - Example Audience: `https://api.us.cobalt.io/users/saml/metadata`
-  - For EU data center: `https://api.eu.cobalt.io/users/saml/metadata`
+  - Example Audience: `https://api.us.cobalt.io/v2/orgs/<your-org's-slug>/saml_metadata`
+  - For EU data center: `https://api.eu.cobalt.io/v2/orgs/test-org-api/saml_metadata`
 - We no longer require a **RelayState** within the assertion.
 - Organization Owners can now enable or disable [SSO enforcement](/platform-deep-dive/organization/organization-settings/saml-sso/#enforce-saml-sso).
 


### PR DESCRIPTION
## Changelog

### Updated
1. Entity IDs across the docs
<img width="1254" height="221" alt="image" src="https://github.com/user-attachments/assets/79192118-e47d-4cec-b0ac-36c96dc33724" />


## Preview This Change

To see how this change looks in production, scroll down to **Deploy Preview**. Select the link that looks like `https://deploy-preview-<num>--cobalt-docs.netlify.app/`

## Variables

Help us support a “Write once, publish everywhere” single source of truth. If you see a line that looks like:

`{{% asset-categories %}}`

You’ve found a [shortcode](https://gohugo.io/content-management/shortcodes/) that we include in multiple documents.

You’ll find the content of the shortcode in the following directory:

https://github.com/cobalthq/cobalt-product-public-docs/tree/main/layouts/shortcodes

That shortcode has the same base name as what you see in the PR, such as `asset-categories.html`.

## Checklist for PR Author

[ ] Did you check for broken links and alt text?

Be sure to check for broken links and Alt Text issues. We have a partially automated process,
as described in this section of our repository README:
[Test Links and Alt Attributes](https://github.com/cobalthq/cobalt-product-public-docs/blob/main/README.md#test-links-and-alt-attributes).
